### PR TITLE
Use ubuntu-latest as the host image

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ros:foxy
 
     steps:


### PR DESCRIPTION
This reverts to ubuntu-latest for the host image. Since we run CI in a Docker container, we don't have to stick to a specific version of Ubuntu for the host.