### PR TITLE
ROS2 Porting: Fix scenario_logger

### DIFF
--- a/logger/scenario_logger/CMakeLists.txt
+++ b/logger/scenario_logger/CMakeLists.txt
@@ -18,4 +18,4 @@ ament_auto_add_library(scenario_logger SHARED
   src/logger.cpp
   )
 
-ament_package()
+ament_auto_package()


### PR DESCRIPTION
## Summary
Quick fix for being able to find the `scenario_logger` in other packages such as `scenario_utility`.