### PR TITLE
ROS2 Porting: scenario_utility

### DIFF
--- a/scenario_utility/CMakeLists.txt
+++ b/scenario_utility/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(scenario_utility)
 
 ### Compile options

--- a/scenario_utility/CMakeLists.txt
+++ b/scenario_utility/CMakeLists.txt
@@ -3,7 +3,7 @@ project(scenario_utility)
 
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -24,8 +24,5 @@ ament_auto_add_library(scenario_utility SHARED
   ${SCENARIO_UTILITY_SRC}
 )
 
-ament_auto_package(INSTALL_TO_SHARE
-  launch
-  config
-)
+ament_auto_package()
 

--- a/scenario_utility/CMakeLists.txt
+++ b/scenario_utility/CMakeLists.txt
@@ -3,7 +3,7 @@ project(scenario_utility)
 
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)

--- a/scenario_utility/CMakeLists.txt
+++ b/scenario_utility/CMakeLists.txt
@@ -1,48 +1,31 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(scenario_utility)
 
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  geometry_msgs
-  tf2_ros
-  tf2_geometry_msgs
-  scenario_logger
-  scenario_logger_msgs
-)
+### Dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-find_package(yaml-cpp REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES scenario_utility
-  CATKIN_DEPENDS roscpp geometry_msgs tf2_ros tf2_geometry_msgs scenario_logger scenario_logger_msgs
-#  DEPENDS system_lib
-)
-
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-)
-
-add_library(scenario_utility SHARED
+### Target executable
+set(SCENARIO_UTILITY_SRC
   src/converter.cpp
   src/misc.cpp
   src/parse.cpp
 )
-add_dependencies(scenario_utility ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(scenario_utility
-  ${catkin_LIBRARIES}
-  ${YAML_CPP_LIBRARIES}
+
+ament_auto_add_library(scenario_utility SHARED
+  ${SCENARIO_UTILITY_SRC}
 )
 
-install(TARGETS scenario_utility
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)

--- a/scenario_utility/include/scenario_utility/converter.h
+++ b/scenario_utility/include/scenario_utility/converter.h
@@ -1,8 +1,9 @@
 #ifndef SCENARIO_UTILS_CONVERTER_H_INCLUDED
 #define SCENARIO_UTILS_CONVERTER_H_INCLUDED
 
-#include <geometry_msgs/Quaternion.h>
-#include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/quaternion.hpp>
+#include <geometry_msgs/vector3.hpp>
+
 #include <tf2/transform_datatypes.h>
 
 namespace scenario_utility
@@ -10,8 +11,8 @@ namespace scenario_utility
 inline namespace converter
 {
 
-geometry_msgs::Quaternion convert(geometry_msgs::Vector3 rpy);
-geometry_msgs::Vector3 convert(geometry_msgs::Quaternion quat);
+geometry_msgs::msg::Quaternion convert(geometry_msgs::msg::Vector3 rpy);
+geometry_msgs::msg::Vector3 convert(geometry_msgs::msg::Quaternion quat);
 
 }  // namespace converter
 }  // namespace scenario_utility

--- a/scenario_utility/include/scenario_utility/converter.h
+++ b/scenario_utility/include/scenario_utility/converter.h
@@ -1,8 +1,8 @@
 #ifndef SCENARIO_UTILS_CONVERTER_H_INCLUDED
 #define SCENARIO_UTILS_CONVERTER_H_INCLUDED
 
-#include <geometry_msgs/quaternion.hpp>
-#include <geometry_msgs/vector3.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
 
 #include <tf2/transform_datatypes.h>
 

--- a/scenario_utility/include/scenario_utility/misc.h
+++ b/scenario_utility/include/scenario_utility/misc.h
@@ -41,30 +41,30 @@ constexpr simulation_is operator ||(const simulation_is& lhs,
 }
 
 
-static_assert( ( simulation_is::succeeded && simulation_is::succeeded ) == simulation_is::succeeded );
-static_assert( ( simulation_is::succeeded && simulation_is::ongoing   ) == simulation_is::ongoing   );
-static_assert( ( simulation_is::succeeded && simulation_is::failed    ) == simulation_is::failed    );
+static_assert( ( simulation_is::succeeded && simulation_is::succeeded ) == simulation_is::succeeded, "");
+static_assert( ( simulation_is::succeeded && simulation_is::ongoing   ) == simulation_is::ongoing  , "");
+static_assert( ( simulation_is::succeeded && simulation_is::failed    ) == simulation_is::failed   , "");
 
-static_assert( ( simulation_is::ongoing   && simulation_is::succeeded ) == simulation_is::ongoing   );
-static_assert( ( simulation_is::ongoing   && simulation_is::ongoing   ) == simulation_is::ongoing   );
-static_assert( ( simulation_is::ongoing   && simulation_is::failed    ) == simulation_is::failed    );
+static_assert( ( simulation_is::ongoing   && simulation_is::succeeded ) == simulation_is::ongoing  , "");
+static_assert( ( simulation_is::ongoing   && simulation_is::ongoing   ) == simulation_is::ongoing  , "");
+static_assert( ( simulation_is::ongoing   && simulation_is::failed    ) == simulation_is::failed   , "");
 
-static_assert( ( simulation_is::failed    && simulation_is::succeeded ) == simulation_is::failed    );
-static_assert( ( simulation_is::failed    && simulation_is::ongoing   ) == simulation_is::failed    );
-static_assert( ( simulation_is::failed    && simulation_is::failed    ) == simulation_is::failed    );
+static_assert( ( simulation_is::failed    && simulation_is::succeeded ) == simulation_is::failed   , "");
+static_assert( ( simulation_is::failed    && simulation_is::ongoing   ) == simulation_is::failed   , "");
+static_assert( ( simulation_is::failed    && simulation_is::failed    ) == simulation_is::failed   , "");
 
 
-static_assert( ( simulation_is::succeeded || simulation_is::succeeded ) == simulation_is::succeeded );
-static_assert( ( simulation_is::succeeded || simulation_is::ongoing   ) == simulation_is::succeeded );
-static_assert( ( simulation_is::succeeded || simulation_is::failed    ) == simulation_is::succeeded );
+static_assert( ( simulation_is::succeeded || simulation_is::succeeded ) == simulation_is::succeeded, "");
+static_assert( ( simulation_is::succeeded || simulation_is::ongoing   ) == simulation_is::succeeded, "");
+static_assert( ( simulation_is::succeeded || simulation_is::failed    ) == simulation_is::succeeded, "");
 
-static_assert( ( simulation_is::ongoing   || simulation_is::succeeded ) == simulation_is::succeeded );
-static_assert( ( simulation_is::ongoing   || simulation_is::ongoing   ) == simulation_is::ongoing   );
-static_assert( ( simulation_is::ongoing   || simulation_is::failed    ) == simulation_is::ongoing   );
+static_assert( ( simulation_is::ongoing   || simulation_is::succeeded ) == simulation_is::succeeded, "");
+static_assert( ( simulation_is::ongoing   || simulation_is::ongoing   ) == simulation_is::ongoing  , "");
+static_assert( ( simulation_is::ongoing   || simulation_is::failed    ) == simulation_is::ongoing  , "");
 
-static_assert( ( simulation_is::failed    || simulation_is::succeeded ) == simulation_is::succeeded );
-static_assert( ( simulation_is::failed    || simulation_is::ongoing   ) == simulation_is::ongoing   );
-static_assert( ( simulation_is::failed    || simulation_is::failed    ) == simulation_is::failed    );
+static_assert( ( simulation_is::failed    || simulation_is::succeeded ) == simulation_is::succeeded, "");
+static_assert( ( simulation_is::failed    || simulation_is::ongoing   ) == simulation_is::ongoing  , "");
+static_assert( ( simulation_is::failed    || simulation_is::failed    ) == simulation_is::failed   , "");
 
 // }  inline namespace misc
 // }  namespace scenario_utility

--- a/scenario_utility/include/scenario_utility/parse.h
+++ b/scenario_utility/include/scenario_utility/parse.h
@@ -2,10 +2,11 @@
 #define SCENARIO_UTILS_PARSE_H_INCLUDED
 
 #include <boost/optional.hpp>
-#include <geometry_msgs/PointStamped.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <ros/ros.h>
+#include <geometry_msgs/point_stamped.hpp>
+#include <geometry_msgs/pose_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <scenario_logger/logger.h>
+
 #include <sstream>
 #include <string>
 #include <vector>
@@ -24,10 +25,10 @@ T read_as(const YAML::Node&);
   template <>                                                                  \
   TYPENAME read_as<TYPENAME>(const YAML::Node& node)
 
-READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::Point);
-READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::Quaternion);
-READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::Pose);
-READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::PoseStamped);
+READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Point);
+READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Quaternion);
+READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Pose);
+READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::PoseStamped);
 
 template <typename T>
 T read_essential(const YAML::Node& node, const std::string& key)
@@ -56,10 +57,10 @@ T read_essential(const YAML::Node& node, const std::string& key)
   TYPENAME read_essential<TYPENAME>(                                           \
     const YAML::Node& node, const std::string& key)
 
-READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::Point);
-READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::Quaternion);
-READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::Pose);
-READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::PoseStamped);
+READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Point);
+READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Quaternion);
+READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Pose);
+READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::PoseStamped);
 
 template <typename T>
 T read_optional(

--- a/scenario_utility/include/scenario_utility/parse.h
+++ b/scenario_utility/include/scenario_utility/parse.h
@@ -5,7 +5,7 @@
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-// #include <scenario_logger/logger.h>
+#include <scenario_logger/logger.h>
 
 #include <sstream>
 #include <string>

--- a/scenario_utility/include/scenario_utility/parse.h
+++ b/scenario_utility/include/scenario_utility/parse.h
@@ -2,10 +2,10 @@
 #define SCENARIO_UTILS_PARSE_H_INCLUDED
 
 #include <boost/optional.hpp>
-#include <geometry_msgs/point_stamped.hpp>
-#include <geometry_msgs/pose_stamped.hpp>
+#include <geometry_msgs/msg/point_stamped.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <scenario_logger/logger.h>
+// #include <scenario_logger/logger.h>
 
 #include <sstream>
 #include <string>

--- a/scenario_utility/package.xml
+++ b/scenario_utility/package.xml
@@ -13,7 +13,7 @@
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
-  <!-- <depend>scenario_logger</depend> -->
+  <depend>scenario_logger</depend>
   <depend>scenario_logger_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
 

--- a/scenario_utility/package.xml
+++ b/scenario_utility/package.xml
@@ -1,39 +1,23 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>scenario_utility</name>
   <version>0.0.0</version>
-  <description>The scenario_utility package</description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <description>The scenario_utility package in ROS2</description>
   <maintainer email="masaya@todo.todo">masaya</maintainer>
+  <license>Apache License 2.0</license>
 
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_export_depend>tf2_ros</build_export_depend>
-  <build_export_depend>tf2_geometry_msgs</build_export_depend>
-  <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <depend>scenario_logger</depend>
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <!-- <depend>scenario_logger</depend> -->
   <depend>scenario_logger_msgs</depend>
+  <depend>yaml_cpp_vendor</depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/scenario_utility/src/converter.cpp
+++ b/scenario_utility/src/converter.cpp
@@ -6,9 +6,9 @@ namespace scenario_utility
 {
 namespace converter
 {
-geometry_msgs::Quaternion convert(geometry_msgs::Vector3 rpy)
+geometry_msgs::msg::Quaternion convert(geometry_msgs::msg::Vector3 rpy)
 {
-  geometry_msgs::Quaternion quat;
+  geometry_msgs::msg::Quaternion quat;
   tf2::Quaternion q;
   q.setRPY(rpy.x, rpy.y, rpy.z);
   quat.x = q.x();
@@ -18,13 +18,13 @@ geometry_msgs::Quaternion convert(geometry_msgs::Vector3 rpy)
   return quat;
 }
 
-geometry_msgs::Vector3 convert(geometry_msgs::Quaternion quat)
+geometry_msgs::msg::Vector3 convert(geometry_msgs::msg::Quaternion quat)
 {
   tf2::Quaternion q(quat.x, quat.y, quat.z, quat.w);
   tf2::Matrix3x3 m(q);
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
-  geometry_msgs::Vector3 rpy;
+  geometry_msgs::msg::Vector3 rpy;
   rpy.x = roll;
   rpy.y = pitch;
   rpy.z = yaw;

--- a/scenario_utility/src/misc.cpp
+++ b/scenario_utility/src/misc.cpp
@@ -17,6 +17,9 @@ std::ostream& operator<<(std::ostream& os, const simulation_is& is)
 
   case simulation_is::succeeded:
     return os << "Succeeded";
+
+  default:
+    return os << "Error";
   }
 }
 

--- a/scenario_utility/src/parse.cpp
+++ b/scenario_utility/src/parse.cpp
@@ -13,9 +13,9 @@ inline namespace parse
   static_assert(true, "semicolon required after this macro")
 
 template <>
-geometry_msgs::Point read_as<geometry_msgs::Point>(const YAML::Node& node)
+geometry_msgs::msg::Point read_as<geometry_msgs::msg::Point>(const YAML::Node& node)
 {
-  geometry_msgs::Point point {};
+  geometry_msgs::msg::Point point {};
 
   point.x = read_essential<float>(node, "X");
   point.y = read_essential<float>(node, "Y");
@@ -24,12 +24,12 @@ geometry_msgs::Point read_as<geometry_msgs::Point>(const YAML::Node& node)
   return point;
 }
 
-DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::Point);
+DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::Point);
 
 template <>
-geometry_msgs::Quaternion read_as<geometry_msgs::Quaternion>(const YAML::Node& node)
+geometry_msgs::msg::Quaternion read_as<geometry_msgs::msg::Quaternion>(const YAML::Node& node)
 {
-  geometry_msgs::Quaternion quaternion {};
+  geometry_msgs::msg::Quaternion quaternion {};
 
   quaternion.x = read_essential<float>(node, "X");
   quaternion.y = read_essential<float>(node, "Y");
@@ -39,36 +39,36 @@ geometry_msgs::Quaternion read_as<geometry_msgs::Quaternion>(const YAML::Node& n
   return quaternion;
 }
 
-DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::Quaternion);
+DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::Quaternion);
 
 template <>
-geometry_msgs::Pose read_as<geometry_msgs::Pose>(const YAML::Node& node)
+geometry_msgs::msg::Pose read_as<geometry_msgs::msg::Pose>(const YAML::Node& node)
 {
-  geometry_msgs::Pose pose {};
+  geometry_msgs::msg::Pose pose {};
 
-  pose.position = read_essential<geometry_msgs::Point>(node, "Position");
-  pose.orientation = read_essential<geometry_msgs::Quaternion>(node, "Orientation");
+  pose.position = read_essential<geometry_msgs::msg::Point>(node, "Position");
+  pose.orientation = read_essential<geometry_msgs::msg::Quaternion>(node, "Orientation");
 
   return pose;
 }
 
-DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::Pose);
+DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::Pose);
 
 template <>
-geometry_msgs::PoseStamped read_as<geometry_msgs::PoseStamped>(const YAML::Node& node)
+geometry_msgs::msg::PoseStamped read_as<geometry_msgs::msg::PoseStamped>(const YAML::Node& node)
 {
-  geometry_msgs::PoseStamped pose_stamped {};
+  geometry_msgs::msg::PoseStamped pose_stamped {};
 
   pose_stamped.header.frame_id = read_optional<std::string>(node, "FrameId", "/map");
-  pose_stamped.header.stamp = ros::Time::now();
-  // pose_stamped.pose = read_essential<geometry_msgs::Pose>(node, "Pose");
-  pose_stamped.pose.position = read_essential<geometry_msgs::Point>(node, "Position");
-  pose_stamped.pose.orientation = read_essential<geometry_msgs::Quaternion>(node, "Orientation");
+  // pose_stamped.header.stamp = ros::Time::now();
+  // pose_stamped.pose = read_essential<geometry_msgs::msg::Pose>(node, "Pose");
+  pose_stamped.pose.position = read_essential<geometry_msgs::msg::Point>(node, "Position");
+  pose_stamped.pose.orientation = read_essential<geometry_msgs::msg::Quaternion>(node, "Orientation");
 
   return pose_stamped;
 }
 
-DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::PoseStamped);
+DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::PoseStamped);
 
 std::vector<std::string> split(std::string s)
 {


### PR DESCRIPTION
## Summary

Simple port of `scenario_utility` package which **depends on #9** in order for successful compilation. 

Notable changes:
* This packages requires C++17 in order for static assertions to not output a lot of compilation warnings
* One function in `misc.h` had a return-value warning - added a `default` case. I'm not sure how this might effect downstream processes, maybe someone with more understanding of this package can give more insight.

