### PR TITLE
ROS2 Porting: scenario_api_autoware

### DIFF
--- a/api/scenario_api_autoware/CMakeLists.txt
+++ b/api/scenario_api_autoware/CMakeLists.txt
@@ -10,68 +10,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_auto REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(autoware_planning_msgs REQUIRED)
-find_package(autoware_system_msgs REQUIRED)
-find_package(autoware_perception_msgs REQUIRED)
-find_package(autoware_vehicle_msgs REQUIRED)
-find_package(autoware_debug_msgs REQUIRED)
-find_package(dummy_perception_publisher REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(PCL REQUIRED)
-find_package(pcl_conversions REQUIRED)
-find_package(lanelet2_extension REQUIRED)
-find_package(scenario_api_utils REQUIRED)
-find_package(vehicle_info_util REQUIRED)
+ament_auto_find_build_dependencies()
 
 ### Includes
 include_directories(include)
 
-add_library(scenario_api_autoware
+ament_auto_add_library(scenario_api_autoware
   src/scenario_api_autoware.cpp
 )
 
-set(SCENARIO_API_AUTOWARE_DEPENDENCIES
-  scenario_api_utils
-  sensor_msgs
-  geometry_msgs
-  std_msgs
-  autoware_planning_msgs
-  autoware_system_msgs
-  autoware_perception_msgs
-  autoware_vehicle_msgs
-  autoware_debug_msgs
-  dummy_perception_publisher
-  rclcpp
-  tf2_ros
-  PCL
-  pcl_conversions
-  lanelet2_extension
-  vehicle_info_util
-)
-
-target_include_directories(scenario_api_autoware
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-
-ament_target_dependencies(scenario_api_autoware PUBLIC ${SCENARIO_API_AUTOWARE_DEPENDENCIES})
-target_compile_definitions(scenario_api_autoware PUBLIC ${PCL_DEFINITIONS})
-target_include_directories(scenario_api_autoware PUBLIC ${PCL_INCLUDE_DIRS})
-target_link_libraries(scenario_api_autoware PUBLIC ${PCL_LIBRARIES})
-target_link_directories(scenario_api_autoware PUBLIC ${PCL_LIBRARY_DIRS})
-
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
-
-install(TARGETS scenario_api_autoware
-  DESTINATION lib/${PROJECT_NAME}
-)
-
-ament_package()
+ament_auto_package()

--- a/api/scenario_api_autoware/CMakeLists.txt
+++ b/api/scenario_api_autoware/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(lanelet2_extension REQUIRED)
 find_package(scenario_api_utils REQUIRED)
+find_package(vehicle_info_util REQUIRED)
 # )
 
 ### Includes
@@ -61,6 +62,7 @@ set(SCENARIO_API_AUTOWARE_DEPENDENCIES
   PCL
   pcl_conversions
   lanelet2_extension
+  vehicle_info_util
 )
 
 ament_target_dependencies(scenario_api_autoware ${SCENARIO_API_AUTOWARE_DEPENDENCIES})

--- a/api/scenario_api_autoware/CMakeLists.txt
+++ b/api/scenario_api_autoware/CMakeLists.txt
@@ -1,9 +1,53 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(scenario_api_autoware)
 
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
+# find_package(catkin REQUIRED COMPONENTS
+find_package(ament_cmake_auto REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(autoware_planning_msgs REQUIRED)
+find_package(autoware_system_msgs REQUIRED)
+find_package(autoware_perception_msgs REQUIRED)
+find_package(autoware_vehicle_msgs REQUIRED)
+find_package(dummy_perception_publisher REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(PCL REQUIRED)
+find_package(pcl_conversions REQUIRED)
+find_package(lanelet2_extension REQUIRED)
+find_package(scenario_api_utils REQUIRED)
+# )
+
+### Includes
+include_directories(include)
+
+
+# catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES scenario_api_autoware
+#  CATKIN_DEPENDS scenario_api_utils sensor_msgs geometry_msgs std_msgs autoware_planning_msgs autoware_system_msgs autoware_perception_msgs autoware_vehicle_msgs dummy_perception_publisher roscpp tf2_ros pcl_ros pcl_conversions lanelet2_extension
+# )
+
+# include_directories(
+# include
+# ${catkin_INCLUDE_DIRS}
+# )
+
+add_executable(scenario_api_autoware
+  src/scenario_api_autoware.cpp
+)
+
+set(SCENARIO_API_AUTOWARE_DEPENDENCIES
+  scenario_api_utils
   sensor_msgs
   geometry_msgs
   std_msgs
@@ -12,40 +56,22 @@ find_package(catkin REQUIRED COMPONENTS
   autoware_perception_msgs
   autoware_vehicle_msgs
   dummy_perception_publisher
-  roscpp
+  rclcpp
   tf2_ros
-  pcl_ros
+  PCL
   pcl_conversions
   lanelet2_extension
-  scenario_api_utils
 )
 
-catkin_package(
- INCLUDE_DIRS include
- LIBRARIES scenario_api_autoware
- CATKIN_DEPENDS scenario_api_utils sensor_msgs geometry_msgs std_msgs autoware_planning_msgs autoware_system_msgs autoware_perception_msgs autoware_vehicle_msgs dummy_perception_publisher roscpp tf2_ros pcl_ros pcl_conversions lanelet2_extension
-)
-
-include_directories(
-include
-${catkin_INCLUDE_DIRS}
-)
-
-add_library(scenario_api_autoware SHARED
-src/scenario_api_autoware.cpp
-)
-add_dependencies(scenario_api_autoware ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(scenario_api_autoware
-${catkin_LIBRARIES}
-${YAML_CPP_LIBRARIES}
-)
+ament_target_dependencies(scenario_api_autoware ${SCENARIO_API_AUTOWARE_DEPENDENCIES})
+# add_dependencies(scenario_api_autoware ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+# target_link_libraries(scenario_api_autoware
+#   ${catkin_LIBRARIES}
+#   ${YAML_CPP_LIBRARIES}
+# )
 
 install(TARGETS scenario_api_autoware
-ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  DESTINATION lib/${PROJECT_NAME}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
+ament_package()

--- a/api/scenario_api_autoware/CMakeLists.txt
+++ b/api/scenario_api_autoware/CMakeLists.txt
@@ -9,7 +9,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
-# find_package(catkin REQUIRED COMPONENTS
 find_package(ament_cmake_auto REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -27,24 +26,11 @@ find_package(pcl_conversions REQUIRED)
 find_package(lanelet2_extension REQUIRED)
 find_package(scenario_api_utils REQUIRED)
 find_package(vehicle_info_util REQUIRED)
-# )
 
 ### Includes
 include_directories(include)
 
-
-# catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES scenario_api_autoware
-#  CATKIN_DEPENDS scenario_api_utils sensor_msgs geometry_msgs std_msgs autoware_planning_msgs autoware_system_msgs autoware_perception_msgs autoware_vehicle_msgs dummy_perception_publisher roscpp tf2_ros pcl_ros pcl_conversions lanelet2_extension
-# )
-
-# include_directories(
-# include
-# ${catkin_INCLUDE_DIRS}
-# )
-
-add_executable(scenario_api_autoware
+add_library(scenario_api_autoware
   src/scenario_api_autoware.cpp
 )
 
@@ -67,12 +53,22 @@ set(SCENARIO_API_AUTOWARE_DEPENDENCIES
   vehicle_info_util
 )
 
-ament_target_dependencies(scenario_api_autoware ${SCENARIO_API_AUTOWARE_DEPENDENCIES})
-# add_dependencies(scenario_api_autoware ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-# target_link_libraries(scenario_api_autoware
-#   ${catkin_LIBRARIES}
-#   ${YAML_CPP_LIBRARIES}
-# )
+target_include_directories(scenario_api_autoware
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(scenario_api_autoware PUBLIC ${SCENARIO_API_AUTOWARE_DEPENDENCIES})
+target_compile_definitions(scenario_api_autoware PUBLIC ${PCL_DEFINITIONS})
+target_include_directories(scenario_api_autoware PUBLIC ${PCL_INCLUDE_DIRS})
+target_link_libraries(scenario_api_autoware PUBLIC ${PCL_LIBRARIES})
+target_link_directories(scenario_api_autoware PUBLIC ${PCL_LIBRARY_DIRS})
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
 
 install(TARGETS scenario_api_autoware
   DESTINATION lib/${PROJECT_NAME}

--- a/api/scenario_api_autoware/CMakeLists.txt
+++ b/api/scenario_api_autoware/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(autoware_planning_msgs REQUIRED)
 find_package(autoware_system_msgs REQUIRED)
 find_package(autoware_perception_msgs REQUIRED)
 find_package(autoware_vehicle_msgs REQUIRED)
+find_package(autoware_debug_msgs REQUIRED)
 find_package(dummy_perception_publisher REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -56,6 +57,7 @@ set(SCENARIO_API_AUTOWARE_DEPENDENCIES
   autoware_system_msgs
   autoware_perception_msgs
   autoware_vehicle_msgs
+  autoware_debug_msgs
   dummy_perception_publisher
   rclcpp
   tf2_ros

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -174,13 +174,18 @@ public:
     double judge_dist_thresh = 30.0);
 
 private:
-  // ros::Subscriber sub_state_;  //!< @brief topic subscriber for autoware state
-  // ros::Subscriber sub_pcl_;    //!< @brief topic subscriber for pcl
-  // ros::Subscriber sub_map_;    //!< @brief topic subscriber for map
-  // ros::Subscriber
-  //   sub_route_;  //!< @brief topic subscriber for current route (for check of autoware ready)
-  // ros::Subscriber sub_twist_;           //!< @brief topic subscriber for twist
-  // ros::Subscriber sub_turn_signal_;     //!< @brief topic subscriber for turn signal(blinker)
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr
+    sub_pcl_;  //!< @brief topic subscriber for pcl
+  rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr
+    sub_map_;  //!< @brief topic subscriber for map
+  rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr
+    sub_route_;  //!< @brief topic subscriber for current route (for check of autoware ready)
+  rclcpp::Subscription<autoware_system_msgs::msg::AutowareState>::SharedPtr
+    sub_state_;  //!< @brief topic subscriber for autoware state
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr
+    sub_twist_;  //!< @brief topic subscriber for twist
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr
+    sub_turn_signal_;  //!< @brief topic subscriber for turn signal(blinker)
   // ros::Timer timer_control_fast_;       //!< @brief timer for getting self-position etc
   // ros::Timer timer_control_slow_;       //!< @brief timer for getting total-move distance etc
   // ros::Publisher pub_start_point_;      //!< @brief topic pubscriber for start point

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -38,16 +38,11 @@
 #include <lanelet2_extension/utility/utilities.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-#include <pcl_conversions/pcl_conversions.h>
-// #include <ros/ros.h>
 #include <rclcpp/rclcpp.hpp>
 #include <scenario_api_utils/scenario_api_utils.h>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/bool.hpp>
-// #include <std_msgs/Float32.h>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -77,12 +77,12 @@ struct VehicleData
   double front_overhang;
   double rear_overhang;
   double vehicle_height;
-  double front_from_base() { return front_overhang + wheel_base; };
-  double rear_from_base() { return -rear_overhang; };
+  double max_longitudinal_offset;
+  double min_longitudinal_offset;
+  double max_height_offset;
+  double min_height_offset;
   double left_from_base() { return wheel_tread / 2.0 + wheel_width / 2.0; };
   double right_from_base() { return -(wheel_tread / 2.0 + wheel_width / 2.0); };
-  double top_from_base() { return vehicle_height; };
-  double bottom_from_base() { return 0.0; };
 };
 
 namespace bg = boost::geometry;

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -17,16 +17,17 @@
 #ifndef SCENARIO_API_SCENARIO_API_AUTOWARE_H_INCLUDED
 #define SCENARIO_API_SCENARIO_API_AUTOWARE_H_INCLUDED
 
-#include <autoware_perception_msgs/Semantic.h>
-#include <autoware_perception_msgs/Shape.h>
-#include <autoware_perception_msgs/TrafficLightStateArray.h>
-#include <autoware_planning_msgs/Route.h>
-#include <autoware_system_msgs/AutowareState.h>
-#include <autoware_vehicle_msgs/TurnSignal.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/PoseWithCovarianceStamped.h>
-#include <geometry_msgs/TransformStamped.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <autoware_perception_msgs/msg/semantic.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_state_array.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
+#include <autoware_system_msgs/msg/autoware_state.hpp>
+#include <autoware_vehicle_msgs/msg/turn_signal.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/polygon.hpp>
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
@@ -39,12 +40,13 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <ros/ros.h>
+// #include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <scenario_api_utils/scenario_api_utils.h>
-#include <sensor_msgs/Image.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <std_msgs/Bool.h>
-#include <std_msgs/Float32.h>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/bool.hpp>
+// #include <std_msgs/Float32.h>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -53,6 +55,7 @@
 #include <unistd.h>
 
 #include <boost/uuid/uuid_generators.hpp>
+#include <boost/geometry.hpp>
 #include <chrono>
 #include <deque>
 #include <iostream>
@@ -63,7 +66,7 @@
 #include <vector>
 
 /* define vehicle shape structure*/
-struct Vehicle_Data
+struct VehicleData
 {
   double wheel_radius;
   double wheel_width;
@@ -80,7 +83,12 @@ struct Vehicle_Data
   double bottom_from_base() { return 0.0; };
 };
 
-class ScenarioAPIAutoware
+namespace bg = boost::geometry;
+using Point = bg::model::d2::point_xy<double>;
+using Polygon = bg::model::polygon<Point>;
+using Line = bg::model::linestring<Point>;
+
+class ScenarioAPIAutoware : public rclcpp::Node
 {
 public:
   /**
@@ -99,13 +107,13 @@ public:
 
   // start API
   bool sendStartPoint(
-    const geometry_msgs::Pose pose, const bool wait_autoware_status,
+    const geometry_msgs::msg::Pose pose, const bool wait_autoware_status,
     const std::string & frame_type);
   bool sendGoalPoint(
-    const geometry_msgs::Pose pose, const bool wait_autoware_status,
+    const geometry_msgs::msg::Pose pose, const bool wait_autoware_status,
     const std::string & frame_type);
   bool sendCheckPoint(
-    const geometry_msgs::Pose pose, const bool wait_autoware_status,
+    const geometry_msgs::msg::Pose pose, const bool wait_autoware_status,
     const std::string & frame_type);
   bool sendStartVelocity(const double velocity);
   bool sendEngage(const bool engage);
@@ -116,7 +124,7 @@ public:
 
   // basic self vehicle API
   Pose2D getCurrentPose();
-  geometry_msgs::PoseStamped getCurrentPoseRos();
+  geometry_msgs::msg::PoseStamped getCurrentPoseRos();
   Polygon getSelfPolygon2D();
   double getVehicleTopFromBase();
   double getVehicleBottomFromBase();
@@ -127,8 +135,8 @@ public:
 
   // basic self vehicle API (tools)
   bool shiftEgoPose(
-    const geometry_msgs::Pose & pose, const std::string frame_type,
-    geometry_msgs::Pose * shift_pose);
+    const geometry_msgs::msg::Pose & pose, const std::string frame_type,
+    geometry_msgs::msg::Pose * shift_pose);
 
   // additonal self vehicle API
   bool willLaneChange();  // TODO //!< @brief t4b try to change lanes or not
@@ -137,11 +145,11 @@ public:
   bool approveLaneChange(bool approve_lane_change);
 
   // sensor API
-  std::shared_ptr<sensor_msgs::PointCloud2> getPointCloud();
+  std::shared_ptr<sensor_msgs::msg::PointCloud2> getPointCloud();
 
   // lane API
   bool getCurrentLaneID(
-    int & current_id, double max_dist = 3.0, double max_deleta_yaw = M_PI / 4.0);
+    int & current_id, double max_dist = 3.0, double max_delta_yaw = M_PI / 4.0);
   bool isChangeLaneID();  // future work: // TODO
   bool getDistancefromCenterLine(double & dist_from_center_line);
   bool isInLane();
@@ -155,37 +163,40 @@ public:
   bool getTrafficLightColor(const int traffic_relation_id, std::string * traffic_color);
   bool getTrafficLightArrow(
     const int traffic_relation_id, std::vector<std::string> * const traffic_arrow);
-  bool getTrafficLineCenterPose(const int traffic_relation_id, geometry_msgs::Pose & line_pose);
+  bool getTrafficLineCenterPose(const int traffic_relation_id, geometry_msgs::msg::Pose & line_pose);
   bool getDistanceToTrafficLight(
-    const int traffic_relation_id, const geometry_msgs::Pose self_pose, double & distance);
+    const int traffic_relation_id, const geometry_msgs::msg::Pose self_pose, double & distance);
   bool getDistanceToTrafficLine(
-    const int traffic_relation_id, const geometry_msgs::Pose self_pose, double & distance);
+    const int traffic_relation_id, const geometry_msgs::msg::Pose self_pose, double & distance);
   bool checkOverTrafficLine(
-    const int traffic_relation_id, const geometry_msgs::Pose self_pose, bool & over_line,
+    const int traffic_relation_id, const geometry_msgs::msg::Pose self_pose, bool & over_line,
     double judge_dist_thresh = 30.0);
 
 private:
-  ros::NodeHandle nh_;         //!< @brief ros node handle
-  ros::NodeHandle pnh_;        //!< @brief private ros node handle
-  ros::Subscriber sub_state_;  //!< @brief topic subscriber for autoware state
-  ros::Subscriber sub_pcl_;    //!< @brief topic subscriber for pcl
-  ros::Subscriber sub_map_;    //!< @brief topic subscriber for map
-  ros::Subscriber
-    sub_route_;  //!< @brief topic subscriber for current route (for check of autoware ready)
-  ros::Subscriber sub_twist_;           //!< @brief topic subscriber for twist
-  ros::Subscriber sub_turn_signal_;     //!< @brief topic subscriber for turn signal(blinker)
-  ros::Timer timer_control_fast_;       //!< @brief timer for getting self-position etc
-  ros::Timer timer_control_slow_;       //!< @brief timer for getting total-move distance etc
-  ros::Publisher pub_start_point_;      //!< @brief topic pubscriber for start point
-  ros::Publisher pub_goal_point_;       //!< @brief topic pubscriber for goal point
-  ros::Publisher pub_check_point_;      //!< @brief topic pubscriber for check point
-  ros::Publisher pub_start_velocity_;   //!< @brief topic @publisher for initial velocity
-  ros::Publisher pub_max_velocity_;     //!< @brief topic pubscriber for max velocity
-  ros::Publisher pub_autoware_engage_;  //!< @brief topic pubscriber for autoware engage
-  ros::Publisher
-    pub_traffic_detection_result_;  //!< @brief topic pubscriber for traffic detection result
-  ros::Publisher
-    pub_lane_change_permission_;  //!< @brief topic pubscriber for approval of lane change
+  // ros::Subscriber sub_state_;  //!< @brief topic subscriber for autoware state
+  // ros::Subscriber sub_pcl_;    //!< @brief topic subscriber for pcl
+  // ros::Subscriber sub_map_;    //!< @brief topic subscriber for map
+  // ros::Subscriber
+  //   sub_route_;  //!< @brief topic subscriber for current route (for check of autoware ready)
+  // ros::Subscriber sub_twist_;           //!< @brief topic subscriber for twist
+  // ros::Subscriber sub_turn_signal_;     //!< @brief topic subscriber for turn signal(blinker)
+  // ros::Timer timer_control_fast_;       //!< @brief timer for getting self-position etc
+  // ros::Timer timer_control_slow_;       //!< @brief timer for getting total-move distance etc
+  // ros::Publisher pub_start_point_;      //!< @brief topic pubscriber for start point
+  // ros::Publisher pub_goal_point_;       //!< @brief topic pubscriber for goal point
+  // ros::Publisher pub_check_point_;      //!< @brief topic pubscriber for check point
+  // ros::Publisher pub_start_velocity_;   //!< @brief topic @publisher for initial velocity
+  // ros::Publisher pub_max_velocity_;     //!< @brief topic pubscriber for max velocity
+  // ros::Publisher pub_autoware_engage_;  //!< @brief topic pubscriber for autoware engage
+  // ros::Publisher
+  //   pub_traffic_detection_result_;  //!< @brief topic pubscriber for traffic detection result
+  // ros::Publisher
+  //   pub_lane_change_permission_;  //!< @brief topic pubscriber for approval of lane change
+
+  // TF
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
 
   const double fast_time_control_dt_ = 0.01;
   const double slow_time_control_dt_ = 0.2;
@@ -193,29 +204,24 @@ private:
   bool is_autoware_ready_initialize;
   bool is_autoware_ready_routing;
   std::string autoware_state_;
-  autoware_perception_msgs::TrafficLightStateArray traffic_light_state_;
+  autoware_perception_msgs::msg::TrafficLightStateArray traffic_light_state_;
   double total_move_distance_;
 
   // get msg from topic
-  std::shared_ptr<sensor_msgs::PointCloud2> pcl_ptr_;
-  std::shared_ptr<geometry_msgs::PoseStamped> current_pose_ptr_;
-  std::shared_ptr<geometry_msgs::PoseStamped> previous_pose_ptr_;
-  std::shared_ptr<geometry_msgs::TwistStamped> current_twist_ptr_;
-  std::shared_ptr<geometry_msgs::TwistStamped> previous_twist_ptr_;
-  std::shared_ptr<geometry_msgs::TwistStamped> second_previous_twist_ptr_;
-  std::shared_ptr<autoware_vehicle_msgs::TurnSignal> turn_signal_ptr_;
-  Vehicle_Data vehicle_data_;
+  std::shared_ptr<sensor_msgs::msg::PointCloud2> pcl_ptr_;
+  std::shared_ptr<geometry_msgs::msg::PoseStamped> current_pose_ptr_;
+  std::shared_ptr<geometry_msgs::msg::PoseStamped> previous_pose_ptr_;
+  std::shared_ptr<geometry_msgs::msg::TwistStamped> current_twist_ptr_;
+  std::shared_ptr<geometry_msgs::msg::TwistStamped> previous_twist_ptr_;
+  std::shared_ptr<geometry_msgs::msg::TwistStamped> second_previous_twist_ptr_;
+  std::shared_ptr<autoware_vehicle_msgs::msg::TurnSignal> turn_signal_ptr_;
+  VehicleData vehicle_data_;
 
   // lanelet
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
   std::shared_ptr<lanelet::routing::RoutingGraph> routing_graph_ptr_;
   std::shared_ptr<lanelet::traffic_rules::TrafficRules> traffic_rules_ptr_;
   std::shared_ptr<lanelet::Lanelet> closest_lanelet_ptr_;
-
-  // TF
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_{tf_buffer_};
-  tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
 
   // Traffic Light
   std::string camera_frame_id_;
@@ -228,14 +234,14 @@ private:
 
   // callback function
   void getCurrentPoseFromTF();
-  void timerCallbackFast(const ros::TimerEvent &);
-  void timerCallbackSlow(const ros::TimerEvent &);
-  void callbackPointCloud(const sensor_msgs::PointCloud2::ConstPtr & msg);
-  void callbackMap(const autoware_lanelet2_msgs::MapBin & msg);
-  void callbackRoute(const autoware_planning_msgs::Route & msg);
-  void callbackStatus(const autoware_system_msgs::AutowareState & msg);
-  void callbackTwist(const geometry_msgs::TwistStamped::ConstPtr & msg);
-  void callbackTurnSignal(const autoware_vehicle_msgs::TurnSignal::ConstPtr & msg);
+  void timerCallbackFast();
+  void timerCallbackSlow();
+  void callbackPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
+  void callbackMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg);
+  void callbackRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg);
+  void callbackStatus(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
+  void callbackTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
+  void callbackTurnSignal(const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg);
 
   // function for start API
   bool checkState(const std::string state);
@@ -243,34 +249,34 @@ private:
 
   // function for basic self vehicle API
   double getAccel(
-    const std::shared_ptr<geometry_msgs::TwistStamped> current_twist_ptr,
-    const std::shared_ptr<geometry_msgs::TwistStamped> previous_twist_ptr);
+    const std::shared_ptr<geometry_msgs::msg::TwistStamped> current_twist_ptr,
+    const std::shared_ptr<geometry_msgs::msg::TwistStamped> previous_twist_ptr);
 
   double getJerk(
-    const std::shared_ptr<geometry_msgs::TwistStamped> current_twist_ptr,
-    const std::shared_ptr<geometry_msgs::TwistStamped> previous_twist_ptr,
-    const std::shared_ptr<geometry_msgs::TwistStamped> second_previous_twist_ptr);
+    const std::shared_ptr<geometry_msgs::msg::TwistStamped> current_twist_ptr,
+    const std::shared_ptr<geometry_msgs::msg::TwistStamped> previous_twist_ptr,
+    const std::shared_ptr<geometry_msgs::msg::TwistStamped> second_previous_twist_ptr);
   void updateTotalMoveDistance();
 
   // function for additonal self vehicle API
-  bool getLeftBlinker(std::shared_ptr<autoware_vehicle_msgs::TurnSignal> turn_signal_ptr);
-  bool getRightBlinker(std::shared_ptr<autoware_vehicle_msgs::TurnSignal> turn_signal_ptr);
+  bool getLeftBlinker(std::shared_ptr<autoware_vehicle_msgs::msg::TurnSignal> turn_signal_ptr);
+  bool getRightBlinker(std::shared_ptr<autoware_vehicle_msgs::msg::TurnSignal> turn_signal_ptr);
 
   // function for lane API
   bool getCurrentLaneID(
-    int & current_id, const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+    int & current_id, const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
     const lanelet::LaneletMapPtr & lanelet_map_ptr, double max_dist, double max_deleta_yaw);
   bool getCurrentLeftLaneID(
     int & current_left_id, const std::shared_ptr<lanelet::Lanelet> current_lane);
   bool getDistancefromCenterLine(
-    double & dist_from_center, const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+    double & dist_from_center, const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
     std::shared_ptr<lanelet::Lanelet> current_lanelet);
   bool getDistancefromCenterLine(
-    double & dist_from_center, const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+    double & dist_from_center, const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
     const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr, lanelet::Id lane_id);
 
   bool isInLane(
-    const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+    const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
     std::shared_ptr<lanelet::Lanelet> current_lanelet);
   double getRateInLane();  // TODO get percentage of body in lanelet polygon
 
@@ -285,12 +291,12 @@ private:
   bool setTrafficLightArrow(const int traffic_id, const std::string & traffic_arrow);
   bool resetTrafficLightColor(const int traffic_id);
   bool resetTrafficLightArrow(const int traffic_id);
-  std::vector<geometry_msgs::Point> getTrafficLightPosition(const int traffic_relation_id);
+  std::vector<geometry_msgs::msg::Point> getTrafficLightPosition(const int traffic_relation_id);
   bool getTrafficLineCenterPosition(
-    const int traffic_relation_id, geometry_msgs::Point & line_center);
+    const int traffic_relation_id, geometry_msgs::msg::Point & line_center);
 
   // others
-  Polygon getSelfPolygon2D(Vehicle_Data vd);
+  Polygon getSelfPolygon2D(VehicleData vd);
 };
 
 #endif  // SCENARIO_API_SCENARIO_API_AUTOWARE_H_INCLUDED

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -23,6 +23,7 @@
 #include <autoware_planning_msgs/msg/route.hpp>
 #include <autoware_system_msgs/msg/autoware_state.hpp>
 #include <autoware_vehicle_msgs/msg/turn_signal.hpp>
+#include <autoware_debug_msgs/msg/float32_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -174,6 +175,7 @@ public:
     double judge_dist_thresh = 30.0);
 
 private:
+  /* Subscribers */
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr
     sub_pcl_;  //!< @brief topic subscriber for pcl
   rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr
@@ -186,18 +188,28 @@ private:
     sub_twist_;  //!< @brief topic subscriber for twist
   rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr
     sub_turn_signal_;  //!< @brief topic subscriber for turn signal(blinker)
-  // ros::Timer timer_control_fast_;       //!< @brief timer for getting self-position etc
-  // ros::Timer timer_control_slow_;       //!< @brief timer for getting total-move distance etc
-  // ros::Publisher pub_start_point_;      //!< @brief topic pubscriber for start point
-  // ros::Publisher pub_goal_point_;       //!< @brief topic pubscriber for goal point
-  // ros::Publisher pub_check_point_;      //!< @brief topic pubscriber for check point
-  // ros::Publisher pub_start_velocity_;   //!< @brief topic @publisher for initial velocity
-  // ros::Publisher pub_max_velocity_;     //!< @brief topic pubscriber for max velocity
-  // ros::Publisher pub_autoware_engage_;  //!< @brief topic pubscriber for autoware engage
-  // ros::Publisher
-  //   pub_traffic_detection_result_;  //!< @brief topic pubscriber for traffic detection result
-  // ros::Publisher
-  //   pub_lane_change_permission_;  //!< @brief topic pubscriber for approval of lane change
+
+  /* Timers */
+  rclcpp::TimerBase::SharedPtr timer_control_fast_;       //!< @brief timer for getting self-position etc
+  rclcpp::TimerBase::SharedPtr timer_control_slow_;       //!< @brief timer for getting total-move distance etc
+
+  /* Publishers */
+  rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
+    pub_start_point_;  //!< @brief topic pubscriber for start point
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr
+    pub_goal_point_;  //!< @brief topic pubscriber for goal point
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr
+    pub_start_velocity_;  //!< @brief topic @publisher for initial velocity
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr
+    pub_autoware_engage_;  //!< @brief topic pubscriber for autoware engage
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr
+    pub_max_velocity_;  //!< @brief topic pubscriber for max velocity
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr
+    pub_lane_change_permission_;  //!< @brief topic pubscriber for approval of lane change
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr
+    pub_check_point_;  //!< @brief topic pubscriber for check point
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightStateArray>::SharedPtr
+    pub_traffic_detection_result_;  //!< @brief topic pubscriber for traffic detection result
 
   // TF
   tf2_ros::Buffer tf_buffer_;

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -72,13 +72,13 @@ using Point = bg::model::d2::point_xy<double>;
 using Polygon = bg::model::polygon<Point>;
 using Line = bg::model::linestring<Point>;
 
-class ScenarioAPIAutoware : public rclcpp::Node
+class ScenarioAPIAutoware
 {
 public:
   /**
    * @brief constructor
    */
-  ScenarioAPIAutoware();
+  ScenarioAPIAutoware(rclcpp::Node::SharedPtr node);
 
   /**
    * @brief destructor
@@ -157,6 +157,7 @@ public:
     double judge_dist_thresh = 30.0);
 
 private:
+  rclcpp::Node::SharedPtr node_;
   /* Subscribers */
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr
     sub_pcl_;  //!< @brief topic subscriber for pcl

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -53,6 +53,7 @@
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 #include <unistd.h>
+#include <vehicle_info_util/vehicle_info.hpp>
 
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/geometry.hpp>
@@ -197,6 +198,9 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
   tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
+
+  // Get Vehicle dimensions
+  vehicle_info_util::VehicleInfo vehicle_info_;
 
   const double fast_time_control_dt_ = 0.01;
   const double slow_time_control_dt_ = 0.2;

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.h
@@ -17,8 +17,6 @@
 #ifndef SCENARIO_API_SCENARIO_API_AUTOWARE_H_INCLUDED
 #define SCENARIO_API_SCENARIO_API_AUTOWARE_H_INCLUDED
 
-#include <autoware_perception_msgs/msg/semantic.hpp>
-#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_state_array.hpp>
 #include <autoware_planning_msgs/msg/route.hpp>
 #include <autoware_system_msgs/msg/autoware_state.hpp>
@@ -26,40 +24,29 @@
 #include <autoware_debug_msgs/msg/float32_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
-#include <geometry_msgs/msg/polygon.hpp>
 #include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
-#include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 #include <lanelet2_extension/utility/message_conversion.h>
 #include <lanelet2_extension/utility/utilities.h>
 #include <lanelet2_routing/RoutingGraph.h>
-#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 #include <rclcpp/rclcpp.hpp>
 #include <scenario_api_utils/scenario_api_utils.h>
-#include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
-#include <unistd.h>
 #include <vehicle_info_util/vehicle_info.hpp>
 
-#include <boost/uuid/uuid_generators.hpp>
 #include <boost/geometry.hpp>
 #include <chrono>
-#include <deque>
 #include <iostream>
 #include <limits>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 /* define vehicle shape structure*/
@@ -209,7 +196,6 @@ private:
   // TF
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
-  tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
 
   // Get Vehicle dimensions
   vehicle_info_util::VehicleInfo vehicle_info_;

--- a/api/scenario_api_autoware/package.xml
+++ b/api/scenario_api_autoware/package.xml
@@ -22,8 +22,6 @@
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>libpcl-all-dev</depend>
-  <depend>pcl_conversions</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>scenario_api_utils</depend>

--- a/api/scenario_api_autoware/package.xml
+++ b/api/scenario_api_autoware/package.xml
@@ -26,6 +26,8 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>scenario_api_utils</depend>
+  <depend>vehicle_info_util</depend>
+  <depend>boost</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/api/scenario_api_autoware/package.xml
+++ b/api/scenario_api_autoware/package.xml
@@ -18,7 +18,6 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>autoware_debug_msgs</depend>
-  <depend>dummy_perception_publisher</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/api/scenario_api_autoware/package.xml
+++ b/api/scenario_api_autoware/package.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
-
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>scenario_api_autoware</name>
   <version>0.0.0</version>
-  <description>The scenario_api_autoware package</description>
+  <description>The scenario_api_autoware ROS2 package</description>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <author email="tomoya.kimura@tier4.jp">Tomoya Kimura</author>
-  <license>Apache 2</license>
+  <license>Apache License 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -18,12 +18,16 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>dummy_perception_publisher</depend>
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>pcl_ros</depend>
+  <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>scenario_api_utils</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/api/scenario_api_autoware/package.xml
+++ b/api/scenario_api_autoware/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_system_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>autoware_debug_msgs</depend>
   <depend>dummy_perception_publisher</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -23,26 +23,27 @@ ScenarioAPIAutoware::ScenarioAPIAutoware()
   tf_buffer_(this->get_clock()),
   tf_listener_(tf_buffer_),
   static_tf_broadcaster_(*this),
+  vehicle_info_(vehicle_info_util::VehicleInfo::create(*this)),
   is_autoware_ready_initialize(false),
   is_autoware_ready_routing(false),
   total_move_distance_(0.0)
 {
   /* Get Parameter*/
-  // pnh_.param<std::string>("camera_frame_id", camera_frame_id_, "camera_link");
+  camera_frame_id_ = this->declare_parameter<std::string>("camera_frame_id", "camera_link");
 
   //parameter for getMoveDistance
-  // pnh_.param<bool>("rosparam/add_simulator_noise", add_simulator_noise_, true);
-  // pnh_.param<double>("rosparam/simulator_pos_noise", simulator_noise_pos_dev_, 0.1);
-  // pnh_.param<double>("rosparam/max_velocity", autoware_max_velocity_, 30.0);
+  add_simulator_noise_ = this->declare_parameter<bool>("rosparam/add_simulator_noise", true);
+  simulator_noise_pos_dev_ = this->declare_parameter<double>("rosparam/simulator_pos_noise", 0.1);
+  autoware_max_velocity_ = this->declare_parameter<double>("rosparam/max_velocity", 30.0);
 
   /* Scenario parameters*/
-  // vehicle_data_.wheel_radius = waitForParam<double>(pnh_, "/vehicle_info/wheel_radius");
-  // vehicle_data_.wheel_width = waitForParam<double>(pnh_, "/vehicle_info/wheel_width");
-  // vehicle_data_.wheel_base = waitForParam<double>(pnh_, "/vehicle_info/wheel_base");
-  // vehicle_data_.wheel_tread = waitForParam<double>(pnh_, "/vehicle_info/wheel_tread");
-  // vehicle_data_.front_overhang = waitForParam<double>(pnh_, "/vehicle_info/front_overhang");
-  // vehicle_data_.rear_overhang = waitForParam<double>(pnh_, "/vehicle_info/rear_overhang");
-  // vehicle_data_.vehicle_height = waitForParam<double>(pnh_, "/vehicle_info/vehicle_height");
+  vehicle_data_.wheel_radius = vehicle_info_.wheel_radius_m_;
+  vehicle_data_.wheel_width = vehicle_info_.wheel_width_m_;
+  vehicle_data_.wheel_base = vehicle_info_.wheel_base_m_;
+  vehicle_data_.wheel_tread = vehicle_info_.wheel_tread_m_;
+  vehicle_data_.front_overhang = vehicle_info_.front_overhang_m_;
+  vehicle_data_.rear_overhang = vehicle_info_.rear_overhang_m_;
+  vehicle_data_.vehicle_height = vehicle_info_.vehicle_height_m_;
 
   /* register callback*/
   // sub_pcl_ = pnh_.subscribe("input/pointcloud", 1, &ScenarioAPIAutoware::callbackPointCloud, this);

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -22,7 +22,6 @@ ScenarioAPIAutoware::ScenarioAPIAutoware()
 : Node("scenario_api_autoware"),
   tf_buffer_(this->get_clock()),
   tf_listener_(tf_buffer_),
-  static_tf_broadcaster_(*this),
   vehicle_info_(vehicle_info_util::VehicleInfo::create(*this)),
   is_autoware_ready_initialize(false),
   is_autoware_ready_routing(false),

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -46,14 +46,24 @@ ScenarioAPIAutoware::ScenarioAPIAutoware()
   vehicle_data_.vehicle_height = vehicle_info_.vehicle_height_m_;
 
   /* register callback*/
-  // sub_pcl_ = pnh_.subscribe("input/pointcloud", 1, &ScenarioAPIAutoware::callbackPointCloud, this);
-  // sub_map_ = pnh_.subscribe("input/vectormap", 10, &ScenarioAPIAutoware::callbackMap, this);
-  // sub_route_ = pnh_.subscribe("input/route", 1, &ScenarioAPIAutoware::callbackRoute, this);
-  // sub_state_ =
-  //   pnh_.subscribe("input/autoware_state", 1, &ScenarioAPIAutoware::callbackStatus, this);
-  // sub_twist_ = pnh_.subscribe("input/vehicle_twist", 1, &ScenarioAPIAutoware::callbackTwist, this);
-  // sub_turn_signal_ =
-  //   pnh_.subscribe("input/signal_command", 1, &ScenarioAPIAutoware::callbackTurnSignal, this);
+  sub_pcl_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+    "input/pointcloud", rclcpp::QoS{1},
+    std::bind(&ScenarioAPIAutoware::callbackPointCloud, this, std::placeholders::_1));
+  sub_map_ = this->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
+    "input/vectormap", rclcpp::QoS{10},
+    std::bind(&ScenarioAPIAutoware::callbackMap, this, std::placeholders::_1));
+  sub_route_ = this->create_subscription<autoware_planning_msgs::msg::Route>(
+    "input/route", rclcpp::QoS{1},
+    std::bind(&ScenarioAPIAutoware::callbackRoute, this, std::placeholders::_1));
+  sub_state_ = this->create_subscription<autoware_system_msgs::msg::AutowareState>(
+    "input/autoware_state", rclcpp::QoS{1},
+    std::bind(&ScenarioAPIAutoware::callbackStatus, this, std::placeholders::_1));
+  sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+    "input/vehicle_twist", rclcpp::QoS{1},
+    std::bind(&ScenarioAPIAutoware::callbackTwist, this, std::placeholders::_1));
+  sub_turn_signal_ = this->create_subscription<autoware_vehicle_msgs::msg::TurnSignal>(
+    "input/signal_command", rclcpp::QoS{1},
+    std::bind(&ScenarioAPIAutoware::callbackTurnSignal, this, std::placeholders::_1));
   // timer_control_fast_ = pnh_.createTimer(
   //   ros::Duration(fast_time_control_dt_), &ScenarioAPIAutoware::timerCallbackFast, this);
   // timer_control_slow_ = pnh_.createTimer(

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -44,6 +44,10 @@ ScenarioAPIAutoware::ScenarioAPIAutoware()
   vehicle_data_.front_overhang = vehicle_info_.front_overhang_m_;
   vehicle_data_.rear_overhang = vehicle_info_.rear_overhang_m_;
   vehicle_data_.vehicle_height = vehicle_info_.vehicle_height_m_;
+  vehicle_data_.max_longitudinal_offset = vehicle_info_.max_longitudinal_offset_m_;
+  vehicle_data_.min_longitudinal_offset = vehicle_info_.min_longitudinal_offset_m_;
+  vehicle_data_.max_height_offset = vehicle_info_.max_height_offset_m_;
+  vehicle_data_.min_height_offset = vehicle_info_.min_height_offset_m_;
 
   /* register data callback*/
   sub_pcl_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
@@ -439,9 +443,9 @@ geometry_msgs::msg::PoseStamped ScenarioAPIAutoware::getCurrentPoseRos() { retur
 
 Polygon ScenarioAPIAutoware::getSelfPolygon2D() { return getSelfPolygon2D(vehicle_data_); }
 
-double ScenarioAPIAutoware::getVehicleTopFromBase() { return vehicle_data_.top_from_base(); }
+double ScenarioAPIAutoware::getVehicleTopFromBase() { return vehicle_data_.max_height_offset; }
 
-double ScenarioAPIAutoware::getVehicleBottomFromBase() { return vehicle_data_.bottom_from_base(); }
+double ScenarioAPIAutoware::getVehicleBottomFromBase() { return vehicle_data_.min_height_offset; }
 
 double ScenarioAPIAutoware::getVelocity() { return current_twist_ptr_->twist.linear.x; }
 
@@ -1133,7 +1137,7 @@ bool ScenarioAPIAutoware::checkOverTrafficLine(
     return true;
   }
 
-  if (distance2line < vehicle_data_.front_from_base()) {
+  if (distance2line < vehicle_data_.max_longitudinal_offset) {
     //front of the car is over the line
     over_line = true;
     return true;
@@ -1232,10 +1236,8 @@ Polygon ScenarioAPIAutoware::getSelfPolygon2D(VehicleData vd)
 {
   double left = vd.left_from_base();
   double right = vd.right_from_base();
-  double front = vd.front_from_base();
-  double rear = vd.rear_from_base();
-  double top = vd.top_from_base();
-  double bottom = vd.bottom_from_base();
+  double front = vd.max_longitudinal_offset;
+  double rear = vd.min_longitudinal_offset;
 
   // create polygon of self body shape
   Polygon poly;

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -16,156 +16,159 @@
 
 #include <scenario_api_autoware/scenario_api_autoware.h>
 
+#include <boost/assign/list_of.hpp>
+
 ScenarioAPIAutoware::ScenarioAPIAutoware()
-: nh_(""),
-  pnh_("~"),
+: Node("scenario_api_autoware"),
+  tf_buffer_(this->get_clock()),
   tf_listener_(tf_buffer_),
+  static_tf_broadcaster_(*this),
   is_autoware_ready_initialize(false),
   is_autoware_ready_routing(false),
   total_move_distance_(0.0)
 {
   /* Get Parameter*/
-  pnh_.param<std::string>("camera_frame_id", camera_frame_id_, "camera_link");
+  // pnh_.param<std::string>("camera_frame_id", camera_frame_id_, "camera_link");
 
   //parameter for getMoveDistance
-  pnh_.param<bool>("rosparam/add_simulator_noise", add_simulator_noise_, true);
-  pnh_.param<double>("rosparam/simulator_pos_noise", simulator_noise_pos_dev_, 0.1);
-  pnh_.param<double>("rosparam/max_velocity", autoware_max_velocity_, 30.0);
+  // pnh_.param<bool>("rosparam/add_simulator_noise", add_simulator_noise_, true);
+  // pnh_.param<double>("rosparam/simulator_pos_noise", simulator_noise_pos_dev_, 0.1);
+  // pnh_.param<double>("rosparam/max_velocity", autoware_max_velocity_, 30.0);
 
   /* Scenario parameters*/
-  vehicle_data_.wheel_radius = waitForParam<double>(pnh_, "/vehicle_info/wheel_radius");
-  vehicle_data_.wheel_width = waitForParam<double>(pnh_, "/vehicle_info/wheel_width");
-  vehicle_data_.wheel_base = waitForParam<double>(pnh_, "/vehicle_info/wheel_base");
-  vehicle_data_.wheel_tread = waitForParam<double>(pnh_, "/vehicle_info/wheel_tread");
-  vehicle_data_.front_overhang = waitForParam<double>(pnh_, "/vehicle_info/front_overhang");
-  vehicle_data_.rear_overhang = waitForParam<double>(pnh_, "/vehicle_info/rear_overhang");
-  vehicle_data_.vehicle_height = waitForParam<double>(pnh_, "/vehicle_info/vehicle_height");
+  // vehicle_data_.wheel_radius = waitForParam<double>(pnh_, "/vehicle_info/wheel_radius");
+  // vehicle_data_.wheel_width = waitForParam<double>(pnh_, "/vehicle_info/wheel_width");
+  // vehicle_data_.wheel_base = waitForParam<double>(pnh_, "/vehicle_info/wheel_base");
+  // vehicle_data_.wheel_tread = waitForParam<double>(pnh_, "/vehicle_info/wheel_tread");
+  // vehicle_data_.front_overhang = waitForParam<double>(pnh_, "/vehicle_info/front_overhang");
+  // vehicle_data_.rear_overhang = waitForParam<double>(pnh_, "/vehicle_info/rear_overhang");
+  // vehicle_data_.vehicle_height = waitForParam<double>(pnh_, "/vehicle_info/vehicle_height");
 
   /* register callback*/
-  sub_pcl_ = pnh_.subscribe("input/pointcloud", 1, &ScenarioAPIAutoware::callbackPointCloud, this);
-  sub_map_ = pnh_.subscribe("input/vectormap", 10, &ScenarioAPIAutoware::callbackMap, this);
-  sub_route_ = pnh_.subscribe("input/route", 1, &ScenarioAPIAutoware::callbackRoute, this);
-  sub_state_ =
-    pnh_.subscribe("input/autoware_state", 1, &ScenarioAPIAutoware::callbackStatus, this);
-  sub_twist_ = pnh_.subscribe("input/vehicle_twist", 1, &ScenarioAPIAutoware::callbackTwist, this);
-  sub_turn_signal_ =
-    pnh_.subscribe("input/signal_command", 1, &ScenarioAPIAutoware::callbackTurnSignal, this);
-  timer_control_fast_ = pnh_.createTimer(
-    ros::Duration(fast_time_control_dt_), &ScenarioAPIAutoware::timerCallbackFast, this);
-  timer_control_slow_ = pnh_.createTimer(
-    ros::Duration(slow_time_control_dt_), &ScenarioAPIAutoware::timerCallbackSlow, this);
+  // sub_pcl_ = pnh_.subscribe("input/pointcloud", 1, &ScenarioAPIAutoware::callbackPointCloud, this);
+  // sub_map_ = pnh_.subscribe("input/vectormap", 10, &ScenarioAPIAutoware::callbackMap, this);
+  // sub_route_ = pnh_.subscribe("input/route", 1, &ScenarioAPIAutoware::callbackRoute, this);
+  // sub_state_ =
+  //   pnh_.subscribe("input/autoware_state", 1, &ScenarioAPIAutoware::callbackStatus, this);
+  // sub_twist_ = pnh_.subscribe("input/vehicle_twist", 1, &ScenarioAPIAutoware::callbackTwist, this);
+  // sub_turn_signal_ =
+  //   pnh_.subscribe("input/signal_command", 1, &ScenarioAPIAutoware::callbackTurnSignal, this);
+  // timer_control_fast_ = pnh_.createTimer(
+  //   ros::Duration(fast_time_control_dt_), &ScenarioAPIAutoware::timerCallbackFast, this);
+  // timer_control_slow_ = pnh_.createTimer(
+  //   ros::Duration(slow_time_control_dt_), &ScenarioAPIAutoware::timerCallbackSlow, this);
 
   /* register publisher */
-  pub_start_point_ =
-    pnh_.advertise<geometry_msgs::PoseWithCovarianceStamped>("output/start_point", 1, true);
-  pub_goal_point_ = pnh_.advertise<geometry_msgs::PoseStamped>("output/goal_point", 1, true);
-  pub_check_point_ = pnh_.advertise<geometry_msgs::PoseStamped>("output/check_point", 10, true);
-  pub_start_velocity_ =
-    pnh_.advertise<geometry_msgs::TwistStamped>("output/initial_velocity", 1, true);
-  pub_autoware_engage_ = pnh_.advertise<std_msgs::Bool>("output/autoware_engage", 1, true);
-  pub_max_velocity_ = pnh_.advertise<std_msgs::Float32>("output/limit_velocity", 1, true);
-  pub_traffic_detection_result_ = pnh_.advertise<autoware_perception_msgs::TrafficLightStateArray>(
-    "output/traffic_detection_result", 10, true);
-  pub_lane_change_permission_ =
-    pnh_.advertise<std_msgs::Bool>("output/lane_change_permission", 1, true);
+  // pub_start_point_ =
+  //   pnh_.advertise<geometry_msgs::PoseWithCovarianceStamped>("output/start_point", 1, true);
+  // pub_goal_point_ = pnh_.advertise<geometry_msgs::PoseStamped>("output/goal_point", 1, true);
+  // pub_check_point_ = pnh_.advertise<geometry_msgs::PoseStamped>("output/check_point", 10, true);
+  // pub_start_velocity_ =
+  //   pnh_.advertise<geometry_msgs::TwistStamped>("output/initial_velocity", 1, true);
+  // pub_autoware_engage_ = pnh_.advertise<std_msgs::Bool>("output/autoware_engage", 1, true);
+  // pub_max_velocity_ = pnh_.advertise<std_msgs::Float32>("output/limit_velocity", 1, true);
+  // pub_traffic_detection_result_ = pnh_.advertise<autoware_perception_msgs::TrafficLightStateArray>(
+  //   "output/traffic_detection_result", 10, true);
+  // pub_lane_change_permission_ =
+  //   pnh_.advertise<std_msgs::Bool>("output/lane_change_permission", 1, true);
 }
 
 ScenarioAPIAutoware::~ScenarioAPIAutoware() {}
 
 // callback function
 
-void ScenarioAPIAutoware::timerCallbackFast(const ros::TimerEvent & te)
+void ScenarioAPIAutoware::timerCallbackFast()
 {
-  ros::spinOnce();
+  // ros::spinOnce();
   getCurrentPoseFromTF();
   pubTrafficLight();
 }
 
-void ScenarioAPIAutoware::timerCallbackSlow(const ros::TimerEvent & te)
+void ScenarioAPIAutoware::timerCallbackSlow()
 {
   updateTotalMoveDistance();
 }
 
-void ScenarioAPIAutoware::callbackPointCloud(const sensor_msgs::PointCloud2::ConstPtr & msg)
+void ScenarioAPIAutoware::callbackPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  pcl_ptr_ = std::make_shared<sensor_msgs::PointCloud2>(*msg);
+  pcl_ptr_ = std::make_shared<sensor_msgs::msg::PointCloud2>(*msg);
 }
 
-void ScenarioAPIAutoware::callbackMap(const autoware_lanelet2_msgs::MapBin & msg)
+void ScenarioAPIAutoware::callbackMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg)
 {
-  ROS_INFO("Start loading lanelet");
+  // ROS_INFO("Start loading lanelet");
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
-    msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
-  ROS_INFO("Map is loaded");
+    *msg, lanelet_map_ptr_);
+  // ROS_INFO("Map is loaded");
 }
 
-void ScenarioAPIAutoware::callbackRoute(const autoware_planning_msgs::Route & msg)
+void ScenarioAPIAutoware::callbackRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg)
 {
   is_autoware_ready_routing = true;  // check autoware rady
 }
 
-void ScenarioAPIAutoware::callbackStatus(const autoware_system_msgs::AutowareState & msg)
+void ScenarioAPIAutoware::callbackStatus(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg)
 {
-  autoware_state_ = msg.state;
-  if (autoware_state_ != autoware_system_msgs::AutowareState::Emergency)
+  autoware_state_ = msg->state;
+  if (autoware_state_ != autoware_system_msgs::msg::AutowareState::EMERGENCY)
     is_autoware_ready_initialize = true;
 }
 
-void ScenarioAPIAutoware::callbackTwist(const geometry_msgs::TwistStamped::ConstPtr & msg)
+void ScenarioAPIAutoware::callbackTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
 {
   if (previous_twist_ptr_ != nullptr) {
     second_previous_twist_ptr_ =
-      std::make_shared<geometry_msgs::TwistStamped>(*previous_twist_ptr_);
+      std::make_shared<geometry_msgs::msg::TwistStamped>(*previous_twist_ptr_);
   }
 
   if (current_twist_ptr_ != nullptr) {
-    previous_twist_ptr_ = std::make_shared<geometry_msgs::TwistStamped>(*current_twist_ptr_);
+    previous_twist_ptr_ = std::make_shared<geometry_msgs::msg::TwistStamped>(*current_twist_ptr_);
   }
-  current_twist_ptr_ = std::make_shared<geometry_msgs::TwistStamped>(*msg);
+  current_twist_ptr_ = std::make_shared<geometry_msgs::msg::TwistStamped>(*msg);
 }
 
 void ScenarioAPIAutoware::callbackTurnSignal(
-  const autoware_vehicle_msgs::TurnSignal::ConstPtr & msg)
+  const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg)
 {
-  turn_signal_ptr_ = std::make_shared<autoware_vehicle_msgs::TurnSignal>(*msg);
+  turn_signal_ptr_ = std::make_shared<autoware_vehicle_msgs::msg::TurnSignal>(*msg);
 }
 
 // basic API
 bool ScenarioAPIAutoware::isAPIReady()
 {
   if (current_pose_ptr_ == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "current_pose is nullptr");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "current_pose is nullptr");
     return false;
   }
 
   if (pcl_ptr_ == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "pointcloud is nullptr");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "pointcloud is nullptr");
     return false;
   }
 
   if (lanelet_map_ptr_ == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "lanelet_map is nullptr");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "lanelet_map is nullptr");
     return false;
   }
 
   if (current_twist_ptr_ == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "current_twist is nullptr");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "current_twist is nullptr");
     return false;
   }
 
   if (previous_twist_ptr_ == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "previous_twist is nullptr");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "previous_twist is nullptr");
     return false;
   }
 
   if (second_previous_twist_ptr_ == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "second_previous_twist is nullptr");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "second_previous_twist is nullptr");
     return false;
   }
 
   if (turn_signal_ptr_ == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "turn_signal is nullptr");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "turn_signal is nullptr");
     return false;
   }
 
@@ -174,165 +177,165 @@ bool ScenarioAPIAutoware::isAPIReady()
 
 bool ScenarioAPIAutoware::waitAPIReady()
 {
-  while (ros::ok()) {
-    if (isAPIReady()) {
-      break;
-    }
-    ros::Rate(10.0).sleep();
-    ros::spinOnce();
-  }
+  // while (ros::ok()) {
+  //   if (isAPIReady()) {
+  //     break;
+  //   }
+  //   ros::Rate(10.0).sleep();
+  //   ros::spinOnce();
+  // }
   return true;  // TODO set timeout
 }
 
 // start API
 bool ScenarioAPIAutoware::sendStartPoint(
-  const geometry_msgs::Pose pose, const bool wait_autoware_status, const std::string & frame_type)
+  const geometry_msgs::msg::Pose pose, const bool wait_autoware_status, const std::string & frame_type)
 {
   // ignore roll/pitch information
   const double yaw = yawFromQuat(pose.orientation);
-  geometry_msgs::PoseWithCovarianceStamped posewcs;
-  posewcs.header.stamp = ros::Time::now();
+  geometry_msgs::msg::PoseWithCovarianceStamped posewcs;
+  posewcs.header.stamp = this->now();
   posewcs.header.frame_id = "map";
 
   //get pose with frame_type
-  geometry_msgs::Pose original_pose;
+  geometry_msgs::msg::Pose original_pose;
   original_pose.position = pose.position;
   original_pose.orientation = quatFromYaw(yaw);
   if (!shiftEgoPose(original_pose, frame_type, &posewcs.pose.pose)) {
     return false;
   }
 
-  pub_start_point_.publish(posewcs);
+  // pub_start_point_.publish(posewcs);
 
   //publish recurssively until self-pose tf is published
   while (!current_pose_ptr_) {
-    ros::Rate(2.0).sleep();
-    pub_start_point_.publish(posewcs);
-    ros::spinOnce();
+    // ros::Rate(2.0).sleep();
+    // pub_start_point_.publish(posewcs);
+    // ros::spinOnce();
   }
 
   if (wait_autoware_status) {
     //publish recurssively until state changes
-    while (!checkState(autoware_system_msgs::AutowareState::WaitingForRoute)) {
-      ros::Rate(2.0).sleep();
-      posewcs.header.stamp = ros::Time::now();
-      pub_start_point_.publish(posewcs);
-      ros::spinOnce();
+    while (!checkState(autoware_system_msgs::msg::AutowareState::WAITING_FOR_ROUTE)) {
+      // ros::Rate(2.0).sleep();
+      posewcs.header.stamp = this->now();
+      // pub_start_point_.publish(posewcs);
+      // ros::spinOnce();
     }
   }
   //In some cases, goalpoint is send soon after startpoint, mission planner cannot plan route.
-  sleep(1.0);  //TODO remove this
+  // sleep(1.0);  //TODO remove this
 
   return true;  // TODO check success(add timeout function)
 }
 
 bool ScenarioAPIAutoware::sendGoalPoint(
-  const geometry_msgs::Pose pose, const bool wait_autoware_status, const std::string & frame_type)
+  const geometry_msgs::msg::Pose pose, const bool wait_autoware_status, const std::string & frame_type)
 {
   // ignore roll/pitch information
   const double yaw = yawFromQuat(pose.orientation);
-  geometry_msgs::PoseStamped posestmp;
-  posestmp.header.stamp = ros::Time::now();
+  geometry_msgs::msg::PoseStamped posestmp;
+  posestmp.header.stamp = this->now();
   posestmp.header.frame_id = "map";
 
   //get pose with frame_type
-  geometry_msgs::Pose original_pose;
+  geometry_msgs::msg::Pose original_pose;
   original_pose.position = pose.position;
   original_pose.orientation = quatFromYaw(yaw);
   if (!shiftEgoPose(original_pose, frame_type, &posestmp.pose)) {
     return false;
   }
 
-  pub_goal_point_.publish(posestmp);
+  // pub_goal_point_.publish(posestmp);
 
   if (wait_autoware_status) {
     //publish recurssively until state changes
-    while (!checkState(autoware_system_msgs::AutowareState::WaitingForEngage)) {
-      ros::Rate(1.0).sleep();
-      posestmp.header.stamp = ros::Time::now();
-      pub_goal_point_.publish(posestmp);
-      ros::spinOnce();
+    while (!checkState(autoware_system_msgs::msg::AutowareState::WAITING_FOR_ENGAGE)) {
+      // ros::Rate(1.0).sleep();
+      posestmp.header.stamp = this->now();
+      // pub_goal_point_.publish(posestmp);
+      // ros::spinOnce();
     }
   }
   //sleep for initial velocity start
   //if there are no sleep from sendgoal to engage,
   //ego vehicle decelerates soon after start
-  ros::Rate(1.0).sleep();
+  // ros::Rate(1.0).sleep();
 
   return true;  // TODO check success(add timeout function)
 }
 
 bool ScenarioAPIAutoware::sendCheckPoint(
-  const geometry_msgs::Pose pose, const bool wait_autoware_status, const std::string & frame_type)
+  const geometry_msgs::msg::Pose pose, const bool wait_autoware_status, const std::string & frame_type)
 {
   // ignore roll/pitch information
   const double yaw = yawFromQuat(pose.orientation);
-  geometry_msgs::PoseStamped posestmp;
-  posestmp.header.stamp = ros::Time::now();
+  geometry_msgs::msg::PoseStamped posestmp;
+  posestmp.header.stamp = this->now();
   posestmp.header.frame_id = "map";
 
   //get pose with frame_type
-  geometry_msgs::Pose original_pose;
+  geometry_msgs::msg::Pose original_pose;
   original_pose.position = pose.position;
   original_pose.orientation = quatFromYaw(yaw);
   if (!shiftEgoPose(original_pose, frame_type, &posestmp.pose)) {
     return false;
   }
 
-  pub_check_point_.publish(posestmp);
+  // pub_check_point_.publish(posestmp);
   if (wait_autoware_status) {
     // wait for message-received and planning
-    waitState(autoware_system_msgs::AutowareState::WaitingForEngage);
+    waitState(autoware_system_msgs::msg::AutowareState::WAITING_FOR_ENGAGE);
   }
   return true;  // TODO check success(add timeout function)
 }
 
 bool ScenarioAPIAutoware::checkState(const std::string state)
 {
-  ROS_INFO_STREAM("autoware_state:" << autoware_state_ << ", target_state" << state << std::endl);
+  // ROS_INFO_STREAM("autoware_state:" << autoware_state_ << ", target_state" << state << std::endl);
   return autoware_state_ == state;
 }
 
 bool ScenarioAPIAutoware::waitState(const std::string state)
 {
   // wait for state change
-  while (ros::ok()) {
-    if (autoware_state_ == state) {
-      break;
-    }
-    ros::Rate(10.0).sleep();
-    ros::spinOnce();
-  }
+  // while (ros::ok()) {
+  //   if (autoware_state_ == state) {
+  //     break;
+  //   }
+  //   ros::Rate(10.0).sleep();
+  //   ros::spinOnce();
+  // }
   return true;  // TODO: set timeout
 }
 
 bool ScenarioAPIAutoware::sendStartVelocity(const double velocity)
 {
-  geometry_msgs::TwistStamped twistmsg;
+  geometry_msgs::msg::TwistStamped twistmsg;
   twistmsg.header.frame_id = "base_link";
-  twistmsg.header.stamp = ros::Time::now();
+  twistmsg.header.stamp = this->now();
   twistmsg.twist.linear.x = velocity;
-  pub_start_velocity_.publish(twistmsg);
+  // pub_start_velocity_.publish(twistmsg);
   return true;  // TODO check success
 }
 
 bool ScenarioAPIAutoware::sendEngage(const bool engage)
 {
-  std_msgs::Bool boolmsg;
+  std_msgs::msg::Bool boolmsg;
   boolmsg.data = engage;
-  pub_autoware_engage_.publish(boolmsg);
+  // pub_autoware_engage_.publish(boolmsg);
   return true;  // TODO check success
 }
 
 bool ScenarioAPIAutoware::waitAutowareInitialize()
 {
-  while (ros::ok()) {
-    if (isAutowareReadyInitialize()) {
-      break;
-    }
-    ros::Rate(10.0).sleep();
-    ros::spinOnce();
-  }
+  // while (ros::ok()) {
+  //   if (isAutowareReadyInitialize()) {
+  //     break;
+  //   }
+  //   ros::Rate(10.0).sleep();
+  //   ros::spinOnce();
+  // }
   return true;
 }
 
@@ -345,21 +348,21 @@ bool ScenarioAPIAutoware::isAutowareReadyRouting()
 
 bool ScenarioAPIAutoware::setMaxSpeed(double velocity)
 {
-  std_msgs::Float32 floatmsg;
-  floatmsg.data = velocity;
-  pub_max_velocity_.publish(floatmsg);
+  // std_msgs::Float32 floatmsg;
+  // floatmsg.data = velocity;
+  // pub_max_velocity_.publish(floatmsg);
   return true;  // TODO check success
 }
 
 // self-vehicle API
 void ScenarioAPIAutoware::getCurrentPoseFromTF(void)
 {
-  geometry_msgs::TransformStamped transform;
-  geometry_msgs::PoseStamped ps;
+  geometry_msgs::msg::TransformStamped transform;
+  geometry_msgs::msg::PoseStamped ps;
   try {
-    transform = tf_buffer_.lookupTransform("map", "base_link", ros::Time(0));
+    transform = tf_buffer_.lookupTransform("map", "base_link", tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "cannot get map to base_link transform. %s", ex.what());
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "cannot get map to base_link transform. %s", ex.what());
     return;
   }
 
@@ -368,7 +371,7 @@ void ScenarioAPIAutoware::getCurrentPoseFromTF(void)
   ps.pose.position.y = transform.transform.translation.y;
   ps.pose.position.z = transform.transform.translation.z;
   ps.pose.orientation = transform.transform.rotation;
-  current_pose_ptr_ = std::make_shared<geometry_msgs::PoseStamped>(ps);
+  current_pose_ptr_ = std::make_shared<geometry_msgs::msg::PoseStamped>(ps);
 }
 
 Pose2D ScenarioAPIAutoware::getCurrentPose()
@@ -380,7 +383,7 @@ Pose2D ScenarioAPIAutoware::getCurrentPose()
   return p;
 }
 
-geometry_msgs::PoseStamped ScenarioAPIAutoware::getCurrentPoseRos() { return *current_pose_ptr_; }
+geometry_msgs::msg::PoseStamped ScenarioAPIAutoware::getCurrentPoseRos() { return *current_pose_ptr_; }
 
 Polygon ScenarioAPIAutoware::getSelfPolygon2D() { return getSelfPolygon2D(vehicle_data_); }
 
@@ -400,33 +403,33 @@ double ScenarioAPIAutoware::getJerk()
 double ScenarioAPIAutoware::getMoveDistance() { return total_move_distance_; }
 
 double ScenarioAPIAutoware::getAccel(
-  const std::shared_ptr<geometry_msgs::TwistStamped> current_twist_ptr,
-  const std::shared_ptr<geometry_msgs::TwistStamped> previous_twist_ptr)
+  const std::shared_ptr<geometry_msgs::msg::TwistStamped> current_twist_ptr,
+  const std::shared_ptr<geometry_msgs::msg::TwistStamped> previous_twist_ptr)
 {
   double c_x = current_twist_ptr->twist.linear.x;
   double p_x = previous_twist_ptr->twist.linear.x;
-  double c_time = current_twist_ptr->header.stamp.toSec();
-  double p_time = previous_twist_ptr->header.stamp.toSec();
+  double c_time = current_twist_ptr->header.stamp.sec;
+  double p_time = previous_twist_ptr->header.stamp.sec;
   if (c_time - p_time <= 0) {
-    ROS_WARN("return invalid accel because of invalid timestamp(twist_ptr)");
+    // ROS_WARN("return invalid accel because of invalid timestamp(twist_ptr)");
   }
   return (c_x - p_x) / (c_time - p_time);  // TODO refine this(use low pass filter?)
 }
 
 double ScenarioAPIAutoware::getJerk(
-  const std::shared_ptr<geometry_msgs::TwistStamped> current_twist_ptr,
-  const std::shared_ptr<geometry_msgs::TwistStamped> previous_twist_ptr,
-  const std::shared_ptr<geometry_msgs::TwistStamped> second_previous_twist_ptr)
+  const std::shared_ptr<geometry_msgs::msg::TwistStamped> current_twist_ptr,
+  const std::shared_ptr<geometry_msgs::msg::TwistStamped> previous_twist_ptr,
+  const std::shared_ptr<geometry_msgs::msg::TwistStamped> second_previous_twist_ptr)
 {
   double c_a = getAccel(current_twist_ptr, previous_twist_ptr);
   double p_a = getAccel(previous_twist_ptr, second_previous_twist_ptr);
   double c_time =
-    (current_twist_ptr->header.stamp.toSec() + previous_twist_ptr->header.stamp.toSec()) / 2.0;
+    (current_twist_ptr->header.stamp.sec + previous_twist_ptr->header.stamp.sec) / 2.0;
   double p_time =
-    (previous_twist_ptr->header.stamp.toSec() + second_previous_twist_ptr->header.stamp.toSec()) /
+    (previous_twist_ptr->header.stamp.sec + second_previous_twist_ptr->header.stamp.sec) /
     2.0;
   if (c_time - p_time <= 0) {
-    ROS_WARN("return invalid jerk because of invalid timestamp(twist_ptr)");
+    // ROS_WARN("return invalid jerk because of invalid timestamp(twist_ptr)");
   }
   return (c_a - p_a) / (c_time - p_time);
 }
@@ -449,7 +452,7 @@ void ScenarioAPIAutoware::updateTotalMoveDistance()
 
   //calculate delta-distance
   const double dt =
-    current_pose_ptr_->header.stamp.toSec() - previous_pose_ptr_.header.stamp.toSec();
+    current_pose_ptr_->header.stamp.sec - previous_pose_ptr_.header.stamp.sec;
   const double dx = current_pose_ptr_->pose.position.x - previous_pose_ptr_.pose.position.x;
   const double dy = current_pose_ptr_->pose.position.y - previous_pose_ptr_.pose.position.y;
   const double dist = std::hypot(dx, dy);  //do not consider height
@@ -461,8 +464,8 @@ void ScenarioAPIAutoware::updateTotalMoveDistance()
     return;
   }
   if (std::fabs(v) > valid_max_velocity_thresh_) {
-    ROS_ERROR_STREAM(
-      "Detect invalid movement. Do not add delta-pose to total-move-distance. v=( " << v << " )");
+    // ROS_ERROR_STREAM(
+    //   "Detect invalid movement. Do not add delta-pose to total-move-distance. v=( " << v << " )");
     previous_pose_ptr_ = *current_pose_ptr_;
     return;
   }
@@ -478,7 +481,7 @@ void ScenarioAPIAutoware::updateTotalMoveDistance()
 }
 
 bool ScenarioAPIAutoware::shiftEgoPose(
-  const geometry_msgs::Pose & pose, const std::string frame_type, geometry_msgs::Pose * shift_pose)
+  const geometry_msgs::msg::Pose & pose, const std::string frame_type, geometry_msgs::msg::Pose * shift_pose)
 {
   //shift pose from farame_type to "Center"
 
@@ -500,29 +503,29 @@ bool ScenarioAPIAutoware::shiftEgoPose(
     return true;
   }
 
-  ROS_ERROR_STREAM(
-    "shiftEGoPose supports only base_link, front_link, and rear_link as frame_type. "
-    << "Now, frame_type is " << frame_type << ".");
+  // ROS_ERROR_STREAM(
+  //   "shiftEGoPose supports only base_link, front_link, and rear_link as frame_type. "
+  //   << "Now, frame_type is " << frame_type << ".");
   return false;
 }
 
 // additonal self vehicle API
 bool ScenarioAPIAutoware::willLaneChange()
 {
-  ROS_WARN_DELAYED_THROTTLE(5.0, "willLaneChange is not perfectly implemented yet.");
+  // ROS_WARN_DELAYED_THROTTLE(5.0, "willLaneChange is not perfectly implemented yet.");
   // TODO fix this (Now, this returns true when left/right turn)
   return (getLeftBlinker() || getRightBlinker());
 }
 
 bool ScenarioAPIAutoware::getLeftBlinker(
-  std::shared_ptr<autoware_vehicle_msgs::TurnSignal> turn_signal_ptr)
+  std::shared_ptr<autoware_vehicle_msgs::msg::TurnSignal> turn_signal_ptr)
 {
-  return (turn_signal_ptr->data == autoware_vehicle_msgs::TurnSignal::LEFT);
-};
+  return (turn_signal_ptr->data == autoware_vehicle_msgs::msg::TurnSignal::LEFT);
+}
 bool ScenarioAPIAutoware::getRightBlinker(
-  std::shared_ptr<autoware_vehicle_msgs::TurnSignal> turn_signal_ptr)
+  std::shared_ptr<autoware_vehicle_msgs::msg::TurnSignal> turn_signal_ptr)
 {
-  return (turn_signal_ptr->data == autoware_vehicle_msgs::TurnSignal::RIGHT);
+  return (turn_signal_ptr->data == autoware_vehicle_msgs::msg::TurnSignal::RIGHT);
 }
 
 bool ScenarioAPIAutoware::getLeftBlinker() { return getLeftBlinker(turn_signal_ptr_); }
@@ -531,14 +534,14 @@ bool ScenarioAPIAutoware::getRightBlinker() { return getRightBlinker(turn_signal
 
 bool ScenarioAPIAutoware::approveLaneChange(bool approve_lane_change)
 {
-  std_msgs::Bool boolmsg;
+  std_msgs::msg::Bool boolmsg;
   boolmsg.data = approve_lane_change;
-  pub_lane_change_permission_.publish(boolmsg);
+  // pub_lane_change_permission_.publish(boolmsg);
   return true;  // TODO check successs
 }
 
 // sensor API
-std::shared_ptr<sensor_msgs::PointCloud2> ScenarioAPIAutoware::getPointCloud() { return pcl_ptr_; }
+std::shared_ptr<sensor_msgs::msg::PointCloud2> ScenarioAPIAutoware::getPointCloud() { return pcl_ptr_; }
 
 // lane API
 bool ScenarioAPIAutoware::getCurrentLaneID(int & current_id, double max_dist, double max_delta_yaw)
@@ -547,7 +550,7 @@ bool ScenarioAPIAutoware::getCurrentLaneID(int & current_id, double max_dist, do
 }
 
 bool ScenarioAPIAutoware::getCurrentLaneID(
-  int & current_id, const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+  int & current_id, const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
   const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr, double max_dist,
   double max_delta_yaw)
 {
@@ -582,7 +585,7 @@ bool ScenarioAPIAutoware::getCurrentLeftLaneID(
   int & current_left_id, const std::shared_ptr<lanelet::Lanelet> current_lane)
 {
   if (current_lane == nullptr) {
-    ROS_WARN("cannot get left lane id (current_lane is nullptr)");
+    // ROS_WARN("cannot get left lane id (current_lane is nullptr)");
     return false;
   }
 
@@ -597,7 +600,7 @@ bool ScenarioAPIAutoware::getCurrentLeftLaneID(
 
 bool ScenarioAPIAutoware::isChangeLaneID()
 {
-  ROS_WARN("isChangeLaneID is not implemented yet.");
+  // ROS_WARN("isChangeLaneID is not implemented yet.");
   // TODO
   return false;
 }
@@ -608,7 +611,7 @@ bool ScenarioAPIAutoware::getDistancefromCenterLine(double & dist_from_center_li
 }
 
 bool ScenarioAPIAutoware::getDistancefromCenterLine(
-  double & dist_from_center, const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+  double & dist_from_center, const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
   const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr, lanelet::Id lane_id)
 {
   std::shared_ptr<lanelet::Lanelet> lanelet =
@@ -617,17 +620,17 @@ bool ScenarioAPIAutoware::getDistancefromCenterLine(
 }
 
 bool ScenarioAPIAutoware::getDistancefromCenterLine(
-  double & dist_from_center, const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+  double & dist_from_center, const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
   std::shared_ptr<lanelet::Lanelet> current_lanelet)
 {
   if (current_lanelet == nullptr or current_pose == nullptr) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "cannot get distance from centerline (nullptr)");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "cannot get distance from centerline (nullptr)");
     return false;
   }
 
   const auto centerline = current_lanelet->centerline2d();
   if (centerline.empty()) {
-    ROS_WARN_DELAYED_THROTTLE(5.0, "cannot get distance from centerline (invalid centerline)");
+    // ROS_WARN_DELAYED_THROTTLE(5.0, "cannot get distance from centerline (invalid centerline)");
     return false;
   }
 
@@ -644,7 +647,7 @@ bool ScenarioAPIAutoware::getDistancefromCenterLine(
 }
 
 bool ScenarioAPIAutoware::isInLane(
-  const std::shared_ptr<geometry_msgs::PoseStamped> & current_pose,
+  const std::shared_ptr<geometry_msgs::msg::PoseStamped> & current_pose,
   std::shared_ptr<lanelet::Lanelet> current_lanelet)
 {
   const auto poly = current_lanelet->polygon2d().basicPolygon();
@@ -665,9 +668,9 @@ bool ScenarioAPIAutoware::setTrafficLightColor(
       // TODO probabilistic expression of traffic light
       for (auto & lamp : tl_state.lamp_states) {
         if (
-          lamp.type == autoware_perception_msgs::LampState::RED ||
-          lamp.type == autoware_perception_msgs::LampState::YELLOW ||
-          lamp.type == autoware_perception_msgs::LampState::GREEN) {
+          lamp.type == autoware_perception_msgs::msg::LampState::RED ||
+          lamp.type == autoware_perception_msgs::msg::LampState::YELLOW ||
+          lamp.type == autoware_perception_msgs::msg::LampState::GREEN) {
           //if lamp color is already given, change color
           lamp.confidence = 1.0;
           lamp.type = getTrafficLampStateFromString(traffic_color);
@@ -675,7 +678,7 @@ bool ScenarioAPIAutoware::setTrafficLightColor(
         }
       }
       //if lamp color is not given yet, append color
-      autoware_perception_msgs::LampState color_lamp;
+      autoware_perception_msgs::msg::LampState color_lamp;
       color_lamp.confidence = 1.0;
       color_lamp.type = getTrafficLampStateFromString(traffic_color);
       tl_state.lamp_states.emplace_back(color_lamp);
@@ -684,9 +687,9 @@ bool ScenarioAPIAutoware::setTrafficLightColor(
   }
 
   // if traffic id does not exist, add new traffic light state
-  autoware_perception_msgs::TrafficLightState tl_state;
+  autoware_perception_msgs::msg::TrafficLightState tl_state;
   tl_state.id = traffic_id;
-  autoware_perception_msgs::LampState lmp_state;
+  autoware_perception_msgs::msg::LampState lmp_state;
   lmp_state.confidence = 1.0;
   lmp_state.type = getTrafficLampStateFromString(traffic_color);
   tl_state.lamp_states.emplace_back(lmp_state);
@@ -725,7 +728,7 @@ bool ScenarioAPIAutoware::setTrafficLightArrow(
         }
       }
       //if same arrow is not given yet, append color
-      autoware_perception_msgs::LampState arrow_lamp;
+      autoware_perception_msgs::msg::LampState arrow_lamp;
       arrow_lamp.confidence = 1.0;
       arrow_lamp.type = getTrafficLampStateFromString(traffic_arrow);
       tl_state.lamp_states.emplace_back(arrow_lamp);
@@ -734,9 +737,9 @@ bool ScenarioAPIAutoware::setTrafficLightArrow(
   }
 
   // if traffic id does not exist, add new traffic light state
-  autoware_perception_msgs::TrafficLightState tl_state;
+  autoware_perception_msgs::msg::TrafficLightState tl_state;
   tl_state.id = traffic_id;
-  autoware_perception_msgs::LampState lmp_state;
+  autoware_perception_msgs::msg::LampState lmp_state;
   lmp_state.confidence = 1.0;
   lmp_state.type = getTrafficLampStateFromString(traffic_arrow);
   tl_state.lamp_states.emplace_back(lmp_state);
@@ -767,12 +770,12 @@ bool ScenarioAPIAutoware::resetTrafficLightColor(const int traffic_id)
     if (tl_state.id == traffic_id) {
       // modify existed traffic light state
       // TODO probabilistic expression of traffic light
-      for (int i = 0; i < tl_state.lamp_states.size(); i++) {
+      for (size_t i = 0; i < tl_state.lamp_states.size(); i++) {
         if (
           //remove color
-          tl_state.lamp_states[i].type == autoware_perception_msgs::LampState::RED ||
-          tl_state.lamp_states[i].type == autoware_perception_msgs::LampState::YELLOW ||
-          tl_state.lamp_states[i].type == autoware_perception_msgs::LampState::GREEN) {
+          tl_state.lamp_states[i].type == autoware_perception_msgs::msg::LampState::RED ||
+          tl_state.lamp_states[i].type == autoware_perception_msgs::msg::LampState::YELLOW ||
+          tl_state.lamp_states[i].type == autoware_perception_msgs::msg::LampState::GREEN) {
           tl_state.lamp_states.erase(tl_state.lamp_states.begin() + i);
           return true;
         }
@@ -811,13 +814,13 @@ bool ScenarioAPIAutoware::resetTrafficLightArrow(const int traffic_id)
       for (auto & lamp : tl_state.lamp_states) {
         if (
           //remove lamp_state without color
-          lamp.type == autoware_perception_msgs::LampState::RED ||
-          lamp.type == autoware_perception_msgs::LampState::YELLOW ||
-          lamp.type == autoware_perception_msgs::LampState::GREEN) {
+          lamp.type == autoware_perception_msgs::msg::LampState::RED ||
+          lamp.type == autoware_perception_msgs::msg::LampState::YELLOW ||
+          lamp.type == autoware_perception_msgs::msg::LampState::GREEN) {
           const uint32_t color_type = lamp.type;
           //reset lamp_states and push color_type
           tl_state.lamp_states.clear();
-          autoware_perception_msgs::LampState lamp;
+          autoware_perception_msgs::msg::LampState lamp;
           lamp.type = color_type;
           lamp.confidence = 1.0;
           tl_state.lamp_states.emplace_back(lamp);
@@ -855,8 +858,8 @@ bool ScenarioAPIAutoware::getTrafficLightColor(
 {
   lanelet::LineStringsOrPolygons3d traffic_lights;
   if (!getTrafficLights(traffic_relation_id, traffic_lights)) {
-    ROS_WARN_STREAM(
-      "traffic light id:" << traffic_relation_id << " is invalid. cannot get traffic light");
+    // ROS_WARN_STREAM(
+    //   "traffic light id:" << traffic_relation_id << " is invalid. cannot get traffic light");
     return false;
   }
   for (const auto & traffic_light : traffic_lights) {
@@ -865,9 +868,9 @@ bool ScenarioAPIAutoware::getTrafficLightColor(
         for (const auto & lamp_state : tl_state.lamp_states) {
           const auto lamp = static_cast<uint8_t>(lamp_state.type);
           if (
-            lamp == autoware_perception_msgs::LampState::RED ||
-            lamp == autoware_perception_msgs::LampState::YELLOW ||
-            lamp == autoware_perception_msgs::LampState::GREEN) {
+            lamp == autoware_perception_msgs::msg::LampState::RED ||
+            lamp == autoware_perception_msgs::msg::LampState::YELLOW ||
+            lamp == autoware_perception_msgs::msg::LampState::GREEN) {
             *traffic_color = getTrafficLampStringFromState(lamp);
             return true;
           }
@@ -878,7 +881,7 @@ bool ScenarioAPIAutoware::getTrafficLightColor(
     *traffic_color = "";
     return true;
   }
-  ROS_WARN_STREAM("traffic light id:" << traffic_relation_id << "is not registered");
+  // ROS_WARN_STREAM("traffic light id:" << traffic_relation_id << "is not registered");
   return false;
 }
 
@@ -887,8 +890,8 @@ bool ScenarioAPIAutoware::getTrafficLightArrow(
 {
   lanelet::LineStringsOrPolygons3d traffic_lights;
   if (!getTrafficLights(traffic_relation_id, traffic_lights)) {
-    ROS_WARN_STREAM(
-      "traffic light id:" << traffic_relation_id << " is invalid. cannot get traffic light");
+    // ROS_WARN_STREAM(
+    //   "traffic light id:" << traffic_relation_id << " is invalid. cannot get traffic light");
     return false;
   }
   traffic_arrow->clear();
@@ -898,10 +901,10 @@ bool ScenarioAPIAutoware::getTrafficLightArrow(
         for (const auto & lamp_state : tl_state.lamp_states) {
           const auto lamp = static_cast<uint8_t>(lamp_state.type);
           if (
-            lamp == autoware_perception_msgs::LampState::UP ||
-            lamp == autoware_perception_msgs::LampState::DOWN ||
-            lamp == autoware_perception_msgs::LampState::LEFT ||
-            lamp == autoware_perception_msgs::LampState::RIGHT) {
+            lamp == autoware_perception_msgs::msg::LampState::UP ||
+            lamp == autoware_perception_msgs::msg::LampState::DOWN ||
+            lamp == autoware_perception_msgs::msg::LampState::LEFT ||
+            lamp == autoware_perception_msgs::msg::LampState::RIGHT) {
             traffic_arrow->emplace_back(getTrafficLampStringFromState(lamp));
           }
         }
@@ -909,21 +912,21 @@ bool ScenarioAPIAutoware::getTrafficLightArrow(
       }
     }
   }
-  ROS_WARN_STREAM("color of traffic light id:" << traffic_relation_id << "is not registered");
+  // ROS_WARN_STREAM("color of traffic light id:" << traffic_relation_id << "is not registered");
   return false;
 }
 
-std::vector<geometry_msgs::Point> ScenarioAPIAutoware::getTrafficLightPosition(
+std::vector<geometry_msgs::msg::Point> ScenarioAPIAutoware::getTrafficLightPosition(
   const int traffic_relation_id)
 {
-  std::vector<geometry_msgs::Point> traffic_points;
+  std::vector<geometry_msgs::msg::Point> traffic_points;
   lanelet::LineStringsOrPolygons3d traffic_lights;
   if (!getTrafficLights(traffic_relation_id, traffic_lights)) {
     return traffic_points;
   }
   for (const auto traffic_light : traffic_lights) {
     auto tl = traffic_light.lineString();
-    geometry_msgs::Point tl_point;
+    geometry_msgs::msg::Point tl_point;
     tl_point.x = tl->front().x();
     tl_point.y = tl->front().y();
     tl_point.z = tl->front().z();
@@ -933,11 +936,11 @@ std::vector<geometry_msgs::Point> ScenarioAPIAutoware::getTrafficLightPosition(
 }
 
 bool ScenarioAPIAutoware::getTrafficLineCenterPosition(
-  const int traffic_relation_id, geometry_msgs::Point & line_center)
+  const int traffic_relation_id, geometry_msgs::msg::Point & line_center)
 {
   if (!lanelet_map_ptr_->regulatoryElementLayer.exists(traffic_relation_id)) {
-    ROS_WARN_STREAM(
-      "RegulatoryElement, id:" << traffic_relation_id << "does not exist. Check the traffic id");
+    // ROS_WARN_STREAM(
+    //   "RegulatoryElement, id:" << traffic_relation_id << "does not exist. Check the traffic id");
     return false;
   }
 
@@ -945,17 +948,17 @@ bool ScenarioAPIAutoware::getTrafficLineCenterPosition(
 
   auto traffic_light_reg_elem = std::dynamic_pointer_cast<lanelet::TrafficLight>(traffic_element);
   if (!traffic_light_reg_elem) {
-    ROS_WARN_STREAM(
-      "Result of dynamic pointer cast of regulatoryElement, id:"
-      << traffic_relation_id << "is nullptr. Check the traffic id");
+    // ROS_WARN_STREAM(
+    //   "Result of dynamic pointer cast of regulatoryElement, id:"
+    //   << traffic_relation_id << "is nullptr. Check the traffic id");
     return false;
   }
 
   lanelet::ConstLineString3d stop_line = *(traffic_light_reg_elem->stopLine());
   const int sl_size = stop_line.size();
   if (sl_size == 0) {
-    ROS_WARN_STREAM(
-      "Stop line of traffic_relation id:" << traffic_relation_id << " does not exist");
+    // ROS_WARN_STREAM(
+    //   "Stop line of traffic_relation id:" << traffic_relation_id << " does not exist");
     return false;
   }
 
@@ -972,10 +975,10 @@ bool ScenarioAPIAutoware::getTrafficLineCenterPosition(
 }
 
 bool ScenarioAPIAutoware::getTrafficLineCenterPose(
-  const int traffic_relation_id, geometry_msgs::Pose & line_pose)
+  const int traffic_relation_id, geometry_msgs::msg::Pose & line_pose)
 {
   //get stop line position
-  geometry_msgs::Pose stop_line_center;
+  geometry_msgs::msg::Pose stop_line_center;
   if (!getTrafficLineCenterPosition(traffic_relation_id, stop_line_center.position)) {
     return false;
   }
@@ -986,7 +989,7 @@ bool ScenarioAPIAutoware::getTrafficLineCenterPose(
 
   //get stop line orientation(input orientation of nearest lane)
   if (nearest_lanelet.empty()) {
-    ROS_WARN_STREAM("Failed to find the closest lane of stop line");
+    // ROS_WARN_STREAM("Failed to find the closest lane of stop line");
     return false;
   }
 
@@ -999,7 +1002,7 @@ bool ScenarioAPIAutoware::getTrafficLineCenterPose(
 }
 
 bool ScenarioAPIAutoware::getDistanceToTrafficLight(
-  const int traffic_relation_id, const geometry_msgs::Pose self_pose, double & distance)
+  const int traffic_relation_id, const geometry_msgs::msg::Pose self_pose, double & distance)
 {
   const auto traffic_lights = getTrafficLightPosition(traffic_relation_id);
   double min_distance = 1e5;
@@ -1023,9 +1026,9 @@ bool ScenarioAPIAutoware::getDistanceToTrafficLight(
 }
 
 bool ScenarioAPIAutoware::getDistanceToTrafficLine(
-  const int traffic_relation_id, const geometry_msgs::Pose self_pose, double & distance)
+  const int traffic_relation_id, const geometry_msgs::msg::Pose self_pose, double & distance)
 {
-  geometry_msgs::Point line_center;
+  geometry_msgs::msg::Point line_center;
   if (!getTrafficLineCenterPosition(traffic_relation_id, line_center)) {
     return false;
   }
@@ -1036,7 +1039,7 @@ bool ScenarioAPIAutoware::getDistanceToTrafficLine(
 }
 
 bool ScenarioAPIAutoware::checkOverTrafficLine(
-  const int traffic_relation_id, const geometry_msgs::Pose self_pose, bool & over_line,
+  const int traffic_relation_id, const geometry_msgs::msg::Pose self_pose, bool & over_line,
   double judge_dist_thresh_)
 {
   double distance2line;
@@ -1050,7 +1053,7 @@ bool ScenarioAPIAutoware::checkOverTrafficLine(
     return true;
   }
 
-  geometry_msgs::Pose line_center;
+  geometry_msgs::msg::Pose line_center;
   if (!getTrafficLineCenterPose(traffic_relation_id, line_center)) {
     return false;
   }
@@ -1079,17 +1082,17 @@ bool ScenarioAPIAutoware::getTrafficLights(
   const int traffic_relation_id, lanelet::LineStringsOrPolygons3d & traffic_lights)
 {
   if (!lanelet_map_ptr_->regulatoryElementLayer.exists(traffic_relation_id)) {
-    ROS_WARN_STREAM(
-      "regulatoryElement, id:" << traffic_relation_id << "does not exist. Check the traffic id");
+    // ROS_WARN_STREAM(
+    //   "regulatoryElement, id:" << traffic_relation_id << "does not exist. Check the traffic id");
     return false;
   }
   auto traffic_element = lanelet_map_ptr_->regulatoryElementLayer.get(traffic_relation_id);
 
   auto traffic_light_reg_elem = std::dynamic_pointer_cast<lanelet::TrafficLight>(traffic_element);
   if (!traffic_light_reg_elem) {
-    ROS_WARN_STREAM(
-      "Result of dynamic pointer cast of regulatoryElement, id:"
-      << traffic_relation_id << "is nullptr. Check the traffic id");
+    // ROS_WARN_STREAM(
+    //   "Result of dynamic pointer cast of regulatoryElement, id:"
+    //   << traffic_relation_id << "is nullptr. Check the traffic id");
     return false;
   }
 
@@ -1103,62 +1106,62 @@ uint8_t ScenarioAPIAutoware::getTrafficLampStateFromString(const std::string & t
   transform(traffic_state_sc.begin(), traffic_state_sc.end(), traffic_state_sc.begin(), toupper);
 
   if (traffic_state_sc == "RED") {
-    return autoware_perception_msgs::LampState::RED;
+    return autoware_perception_msgs::msg::LampState::RED;
   } else if (traffic_state_sc == "YELLOW") {
-    return autoware_perception_msgs::LampState::YELLOW;
+    return autoware_perception_msgs::msg::LampState::YELLOW;
   } else if ((traffic_state_sc == "GREEN" || traffic_state_sc == "BLUE")) {
-    return autoware_perception_msgs::LampState::GREEN;
+    return autoware_perception_msgs::msg::LampState::GREEN;
   } else if (traffic_state_sc == "UP" || traffic_state_sc == "STRAIGHT") {
-    return autoware_perception_msgs::LampState::UP;
+    return autoware_perception_msgs::msg::LampState::UP;
   } else if (traffic_state_sc == "DOWN") {
     //??? what is "DOWN" ...?
-    return autoware_perception_msgs::LampState::DOWN;
+    return autoware_perception_msgs::msg::LampState::DOWN;
   } else if (traffic_state_sc == "LEFT") {
-    return autoware_perception_msgs::LampState::LEFT;
+    return autoware_perception_msgs::msg::LampState::LEFT;
   } else if (traffic_state_sc == "RIGHT") {
-    return autoware_perception_msgs::LampState::RIGHT;
+    return autoware_perception_msgs::msg::LampState::RIGHT;
   }
-  ROS_ERROR_STREAM("invalid traffic_state in getTrafficLampStateFromString: " << traffic_state_sc);
+  // ROS_ERROR_STREAM("invalid traffic_state in getTrafficLampStateFromString: " << traffic_state_sc);
   return 0;
 }
 
 std::string ScenarioAPIAutoware::getTrafficLampStringFromState(const uint8_t lamp_state)
 {
   //reference: https://github.com/tier4/ScenarioFormat/blob/master/format/definition.md/#ArrowType
-  if (lamp_state == autoware_perception_msgs::LampState::RED) {
+  if (lamp_state == autoware_perception_msgs::msg::LampState::RED) {
     return "Red";
   }
-  if (lamp_state == autoware_perception_msgs::LampState::YELLOW) {
+  if (lamp_state == autoware_perception_msgs::msg::LampState::YELLOW) {
     return "Yellow";
   }
-  if (lamp_state == autoware_perception_msgs::LampState::GREEN) {
+  if (lamp_state == autoware_perception_msgs::msg::LampState::GREEN) {
     return "Green";
   }
-  if (lamp_state == autoware_perception_msgs::LampState::UP) {
+  if (lamp_state == autoware_perception_msgs::msg::LampState::UP) {
     return "Straight";
   }
-  if (lamp_state == autoware_perception_msgs::LampState::DOWN) {
+  if (lamp_state == autoware_perception_msgs::msg::LampState::DOWN) {
     return "Down";
   }
-  if (lamp_state == autoware_perception_msgs::LampState::LEFT) {
+  if (lamp_state == autoware_perception_msgs::msg::LampState::LEFT) {
     return "Left";
   }
-  if (lamp_state == autoware_perception_msgs::LampState::RIGHT) {
+  if (lamp_state == autoware_perception_msgs::msg::LampState::RIGHT) {
     return "Right";
   }
-  ROS_ERROR_STREAM("invalid lamp state in getTrafficLampStringFromState");
+  // ROS_ERROR_STREAM("invalid lamp state in getTrafficLampStringFromState");
   return "";
 }
 
 void ScenarioAPIAutoware::pubTrafficLight()
 {
   traffic_light_state_.header.frame_id = camera_frame_id_;
-  traffic_light_state_.header.stamp = ros::Time::now();
-  pub_traffic_detection_result_.publish(traffic_light_state_);
+  traffic_light_state_.header.stamp = this->now();
+  // pub_traffic_detection_result_.publish(traffic_light_state_);
 }
 
 // util
-Polygon ScenarioAPIAutoware::getSelfPolygon2D(Vehicle_Data vd)
+Polygon ScenarioAPIAutoware::getSelfPolygon2D(VehicleData vd)
 {
   double left = vd.left_from_base();
   double right = vd.right_from_base();

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -112,7 +112,7 @@ ScenarioAPIAutoware::~ScenarioAPIAutoware() {}
 
 void ScenarioAPIAutoware::timerCallbackFast()
 {
-  // ros::spinOnce();
+  rclcpp::spin_some(this->get_node_base_interface());
   getCurrentPoseFromTF();
   pubTrafficLight();
 }
@@ -224,13 +224,13 @@ bool ScenarioAPIAutoware::isAPIReady()
 
 bool ScenarioAPIAutoware::waitAPIReady()
 {
-  // while (ros::ok()) {
-  //   if (isAPIReady()) {
-  //     break;
-  //   }
-  //   ros::Rate(10.0).sleep();
-  //   ros::spinOnce();
-  // }
+  while (rclcpp::ok()) {
+    if (isAPIReady()) {
+      break;
+    }
+    rclcpp::Rate(10.0).sleep();
+    rclcpp::spin_some(this->get_node_base_interface());
+  }
   return true;  // TODO set timeout
 }
 
@@ -256,18 +256,18 @@ bool ScenarioAPIAutoware::sendStartPoint(
 
   //publish recurssively until self-pose tf is published
   while (!current_pose_ptr_) {
-    // ros::Rate(2.0).sleep();
+    rclcpp::Rate(2.0).sleep();
     pub_start_point_->publish(posewcs);
-    // ros::spinOnce();
+    rclcpp::spin_some(this->get_node_base_interface());
   }
 
   if (wait_autoware_status) {
     //publish recurssively until state changes
     while (!checkState(autoware_system_msgs::msg::AutowareState::WAITING_FOR_ROUTE)) {
-      // ros::Rate(2.0).sleep();
+      rclcpp::Rate(2.0).sleep();
       posewcs.header.stamp = this->now();
       pub_start_point_->publish(posewcs);
-      // ros::spinOnce();
+      rclcpp::spin_some(this->get_node_base_interface());
     }
   }
   //In some cases, goalpoint is send soon after startpoint, mission planner cannot plan route.
@@ -298,16 +298,16 @@ bool ScenarioAPIAutoware::sendGoalPoint(
   if (wait_autoware_status) {
     //publish recurssively until state changes
     while (!checkState(autoware_system_msgs::msg::AutowareState::WAITING_FOR_ENGAGE)) {
-      // ros::Rate(1.0).sleep();
+      rclcpp::Rate(1.0).sleep();
       posestmp.header.stamp = this->now();
       pub_goal_point_->publish(posestmp);
-      // ros::spinOnce();
+      rclcpp::spin_some(this->get_node_base_interface());
     }
   }
   //sleep for initial velocity start
   //if there are no sleep from sendgoal to engage,
   //ego vehicle decelerates soon after start
-  // ros::Rate(1.0).sleep();
+  rclcpp::Rate(1.0).sleep();
 
   return true;  // TODO check success(add timeout function)
 }
@@ -348,13 +348,13 @@ bool ScenarioAPIAutoware::checkState(const std::string state)
 bool ScenarioAPIAutoware::waitState(const std::string state)
 {
   // wait for state change
-  // while (ros::ok()) {
-  //   if (autoware_state_ == state) {
-  //     break;
-  //   }
-  //   ros::Rate(10.0).sleep();
-  //   ros::spinOnce();
-  // }
+  while (rclcpp::ok()) {
+    if (autoware_state_ == state) {
+      break;
+    }
+    rclcpp::Rate(10.0).sleep();
+    rclcpp::spin_some(this->get_node_base_interface());
+  }
   return true;  // TODO: set timeout
 }
 
@@ -378,13 +378,13 @@ bool ScenarioAPIAutoware::sendEngage(const bool engage)
 
 bool ScenarioAPIAutoware::waitAutowareInitialize()
 {
-  // while (ros::ok()) {
-  //   if (isAutowareReadyInitialize()) {
-  //     break;
-  //   }
-  //   ros::Rate(10.0).sleep();
-  //   ros::spinOnce();
-  // }
+  while (rclcpp::ok()) {
+    if (isAutowareReadyInitialize()) {
+      break;
+    }
+    rclcpp::Rate(10.0).sleep();
+    rclcpp::spin_some(this->get_node_base_interface());
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary

Fairly straightforward port of the `scenario_api_autoware` package. It looks like a lot of lines changed but really its mostly logging and adding the `msg::` part of ROS1 message types - the more interesting changes are noted below.

Notable Changes:
* Remove unused headers including PCL library dependencies which were not used, removed the following package dependencies
  * `pcl_ros`
  * `pcl_conversions`
  * `dummy_perception_publisher`
* Pull in dependencies to `vehicle_info_util`, `autoware_debug_msgs` and `boost` 
* `ros::spinOnce()` -> `rclcpp::spin_some(this->get_node_base_interface())`
* The `bg` (`boost::geometry`) namespace was referenced along with the types `Polygon`, `Point` and `Line` however these were never properly defined anywhere in the code - I'm not sure how this was able to compile before but the following was needed to ensure that the package finds the correct types and compiles properly:
```
namespace bg = boost::geometry;
using Point = bg::model::d2::point_xy<double>;
using Polygon = bg::model::polygon<Point>;
using Line = bg::model::linestring<Point>;
``` 
If someone who has familiarity with the package could verify that these are the correct types as these were the only references to these types I could find within Pilot.Auto and scenario_runner.iv.universe.
* Spelling: `max_deleta_yaw` -> `max_delta_yaw` and casing `Vehicle_Data` -> `VehicleData`
* Remove static transform broadcaster - this appears to be not used

## Discussion Points
* Is `spin_some` really the alternative to `spinOnce` - Since `spin_some` will spin until there is nothing left in the queue to process, whereas `spinOnce` will only call the callback which are available when `spinOnce` is called?
* VehicleData can probably be removed and replaced with vehicle_info_ though the calculations for left_from_base and right_from_base seem to not be done in the vehicle_info_util package - if this is deemed important I can complete the transition.