### PR TITLE
ROS2 Porting: Fix scenario_api_autoware

### DIFF
--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -135,7 +135,7 @@ void ScenarioAPIAutoware::callbackMap(const autoware_lanelet2_msgs::msg::MapBin:
   RCLCPP_INFO(node_->get_logger(), "Start loading lanelet");
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
-    *msg, lanelet_map_ptr_);
+    *msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
   RCLCPP_INFO(node_->get_logger(), "Map is loaded");
 }
 


### PR DESCRIPTION
As pointed out by @cvasfi [here](https://github.com/tier4/Pilot.Auto/pull/101#discussion_r523808358), I didn't to use the correct `lanelet::utils::conversion::fromBinMsg` method during the port of the `scenario_selector` package. I made the same mistake here in `scenario_api_autoware`.