### PR TITLE
[WIP] ROS2 Porting: scenario_conditions

### DIFF
--- a/condition/scenario_conditions/CMakeLists.txt
+++ b/condition/scenario_conditions/CMakeLists.txt
@@ -1,51 +1,26 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(scenario_conditions)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  pluginlib
-  roscpp
-  scenario_api
-  scenario_intersection
-  scenario_utility
-  visualization_msgs
-)
+### Dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES scenario_conditions
-  CATKIN_DEPENDS
-    pluginlib
-    roscpp
-    scenario_api
-    scenario_intersection
-    scenario_utility
-    visualization_msgs
+set(SCENARIO_CONDITIONS_SRC
+  src/condition_visualizer.cpp
 )
 
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${YAML_CPP_INCLUDE_DIR}
+ament_auto_add_library(scenario_conditions SHARED
+  src/condition_manager.cpp 
+  ${SCENARIO_CONDITIONS_SRC}
 )
 
-add_library(scenario_conditions SHARED
-  src/condition_manager.cpp src/condition_visualizer.cpp
-)
-add_dependencies(scenario_conditions ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(scenario_conditions
-  ${catkin_LIBRARIES}
-  ${YAML_CPP_LIBRARIES}
-)
+ament_auto_package()
 
-install(TARGETS scenario_conditions
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)

--- a/condition/scenario_conditions/CMakeLists.txt
+++ b/condition/scenario_conditions/CMakeLists.txt
@@ -4,6 +4,8 @@ project(scenario_conditions)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)

--- a/condition/scenario_conditions/include/scenario_conditions/condition_base.h
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_base.h
@@ -3,8 +3,10 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <scenario_api/scenario_api_core.h>
-#include <scenario_intersection/intersection_manager.h>
+#include <boost/lexical_cast.hpp>
+
+// #include <scenario_api/scenario_api_core.h>
+// #include <scenario_intersection/intersection_manager.h>
 
 namespace scenario_conditions
 {
@@ -21,25 +23,26 @@ public:
   template <typename T>
   using Comparator = std::function<bool(const T &, const T &)>;
 
-  virtual bool update(const std::shared_ptr<scenario_intersection::IntersectionManager> &) = 0;
-  virtual bool configure(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr) = 0;
+  // virtual bool update(const std::shared_ptr<scenario_intersection::IntersectionManager> &) = 0;
+  virtual bool configure(YAML::Node node) = 0;
+  // virtual bool configure(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr) = 0;
 
   const std::string & getName() const noexcept { return name_; }
 
-  const bool getResult() const noexcept { return result_; }
+  bool getResult() const noexcept { return result_; }
 
   const std::string & getType() const noexcept { return type_; }
 
 protected:
-  std::shared_ptr<ScenarioAPI> api_ptr_;
+  // std::shared_ptr<ScenarioAPI> api_ptr_;
   YAML::Node node_;
 
   bool configured_ = false;
   bool keep_ = false;
   bool result_ = false;
 
-  std::string name_;
   std::string type_;
+  std::string name_;
 };
 
 }  // namespace scenario_conditions

--- a/condition/scenario_conditions/include/scenario_conditions/condition_manager.h
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_manager.h
@@ -1,12 +1,13 @@
 #ifndef SCENARIO_CONDITION_CONDITION_MANAGER_H_INCLUDED
 #define SCENARIO_CONDITION_CONDITION_MANAGER_H_INCLUDED
 
-#include <ros/ros.h>
-#include <pluginlib/class_loader.h>
+#include <rclcpp/rclcpp.hpp>
+// #include <class_loader/class_loader.hpp>
+#include <pluginlib/class_loader.hpp>
 
 #include <scenario_conditions/condition_base.h>
 #include <scenario_conditions/condition_visualizer.h>
-#include <scenario_intersection/intersection_manager.h>
+// #include <scenario_intersection/intersection_manager.h>
 #include <scenario_utility/scenario_utility.h>
 
 namespace scenario_conditions
@@ -14,19 +15,23 @@ namespace scenario_conditions
   class ConditionManager
   {
   public:
-    ConditionManager(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr);
+    // ConditionManager(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr, rclcpp::Node::SharedPtr node_ptr);
+    ConditionManager(YAML::Node node, rclcpp::Node::SharedPtr node_ptr);
 
-    simulation_is update(
-      const std::shared_ptr<scenario_intersection::IntersectionManager>&);
+    // simulation_is update(
+    //   const std::shared_ptr<scenario_intersection::IntersectionManager>&);
+    simulation_is update();
 
     using condition_type
-      = boost::shared_ptr<scenario_conditions::ConditionBase>;
+      = std::shared_ptr<scenario_conditions::ConditionBase>;
 
-    void applyVisitorForSuccessConditions(const std::function<void (boost::shared_ptr<ConditionBase>)>& visitor);
-    void applyVisitorForFailureConditions(const std::function<void (boost::shared_ptr<ConditionBase>)>& visitor);
+    void applyVisitorForSuccessConditions(const std::function<void (std::shared_ptr<ConditionBase>)>& visitor);
+    void applyVisitorForFailureConditions(const std::function<void (std::shared_ptr<ConditionBase>)>& visitor);
 
   private:
-    condition_type loadPlugin(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr);
+    rclcpp::Node::SharedPtr node_;
+    // condition_type loadPlugin(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr);
+    condition_type loadPlugin(YAML::Node node);
 
     std::vector<condition_type> success_conditions_,
                                 failure_conditions_;

--- a/condition/scenario_conditions/include/scenario_conditions/condition_manager.h
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_manager.h
@@ -2,7 +2,6 @@
 #define SCENARIO_CONDITION_CONDITION_MANAGER_H_INCLUDED
 
 #include <rclcpp/rclcpp.hpp>
-// #include <class_loader/class_loader.hpp>
 #include <pluginlib/class_loader.hpp>
 
 #include <scenario_conditions/condition_base.h>

--- a/condition/scenario_conditions/include/scenario_conditions/condition_manager.h
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_manager.h
@@ -28,7 +28,6 @@ namespace scenario_conditions
     void applyVisitorForFailureConditions(const std::function<void (std::shared_ptr<ConditionBase>)>& visitor);
 
   private:
-    rclcpp::Node::SharedPtr node_;
     // condition_type loadPlugin(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr);
     condition_type loadPlugin(YAML::Node node);
 

--- a/condition/scenario_conditions/include/scenario_conditions/condition_visualizer.h
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_visualizer.h
@@ -1,7 +1,8 @@
 #ifndef SCENARIO_CONDITIONS_CONDITION_LOGGER_H_INCLUDED
 #define SCENARIO_CONDITIONS_CONDITION_LOGGER_H_INCLUDED
-#include <ros/ros.h>
-#include <visualization_msgs/MarkerArray.h>
+
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 namespace scenario_conditions
 {
@@ -11,14 +12,15 @@ class ConditionManager;
 class ConditionVisualizer
 {
 public:
-  ConditionVisualizer();
+  ConditionVisualizer(const rclcpp::Node::SharedPtr node);
   void publishMarker(ConditionManager& manager);
 
 private:
   void addMarker(std::string name, bool result, bool is_success_condition);
 
-  ros::Publisher pub_marker_;
-  visualization_msgs::MarkerArray marker_array_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_marker_;
+  visualization_msgs::msg::MarkerArray marker_array_;
 };
 }  // namespace scenario_conditions
 #endif  // SCENARIO_CONDITIONS_CONDITION_LOGGER_H_INCLUDED

--- a/condition/scenario_conditions/package.xml
+++ b/condition/scenario_conditions/package.xml
@@ -1,21 +1,25 @@
 <?xml version="1.0"?>
-
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>scenario_conditions</name>
   <version>0.0.0</version>
   <description>The scenario_conditions package</description>
-
   <maintainer email="ms.kataoka@gmail.com">Masaya Kataoka</maintainer>
 
-  <license>TODO</license>
+  <license>Apache License 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <!-- <depend>class_loader</depend> -->
+  <depend>rclcpp</depend>
   <depend>pluginlib</depend>
-  <depend>roscpp</depend>
-  <depend>scenario_api</depend>
-  <depend>scenario_intersection</depend>
+  <!-- <depend>scenario_api</depend> -->
+  <!-- <depend>scenario_intersection</depend> -->
   <depend>scenario_utility</depend>
   <depend>visualization_msgs</depend>
-  <depend>yaml-cpp</depend>
+  <depend>yaml_cpp_vendor</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/condition/scenario_conditions/package.xml
+++ b/condition/scenario_conditions/package.xml
@@ -10,7 +10,6 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <!-- <depend>class_loader</depend> -->
   <depend>rclcpp</depend>
   <depend>pluginlib</depend>
   <!-- <depend>scenario_api</depend> -->

--- a/condition/scenario_conditions/src/condition_manager.cpp
+++ b/condition/scenario_conditions/src/condition_manager.cpp
@@ -45,7 +45,7 @@ ConditionManager::condition_type ConditionManager::loadPlugin(YAML::Node node)
     if (iter == classes.end()) {
       SCENARIO_ERROR_THROW(CATEGORY(), "There is no plugin of type '" << type << "'.");
     } else {
-      std::shared_ptr<scenario_conditions::ConditionBase> plugin(loader.createClassInstance(*iter));
+      auto plugin = loader.createSharedInstance(*iter);
       // plugin->configure(node, api_ptr);
       plugin->configure(node);
       return plugin;

--- a/condition/scenario_conditions/src/condition_manager.cpp
+++ b/condition/scenario_conditions/src/condition_manager.cpp
@@ -4,8 +4,7 @@ namespace scenario_conditions
 {
   // ConditionManager::ConditionManager(YAML::Node node, std::shared_ptr<ScenarioAPI> api_ptr, rclcpp::Node::SharedPtr node_ptr)
 ConditionManager::ConditionManager(YAML::Node node, rclcpp::Node::SharedPtr node_ptr) 
-: node_(node_ptr),
-  visualizer(node_ptr)
+: visualizer(node_ptr)
 {
   try {
     call_with_optional(node, "Success", [&](const auto & node) {

--- a/condition/scenario_conditions/src/condition_visualizer.cpp
+++ b/condition/scenario_conditions/src/condition_visualizer.cpp
@@ -4,17 +4,18 @@
 
 namespace scenario_conditions
 {
-ConditionVisualizer::ConditionVisualizer()
+ConditionVisualizer::ConditionVisualizer(const rclcpp::Node::SharedPtr node)
+: node_(node)
 {
-  auto pnh = ros::NodeHandle("~");
-  pub_marker_ = pnh.advertise<visualization_msgs::MarkerArray>("condition_marker", 1);
+  // auto pnh = ros::NodeHandle("~");
+  pub_marker_ = node_->create_publisher<visualization_msgs::msg::MarkerArray>("condition_marker", rclcpp::QoS{1});
 }
 
 void ConditionVisualizer::publishMarker(ConditionManager& manager)
 {
   marker_array_.markers.clear();
   bool is_success_condition;
-  auto add_func = [this, &is_success_condition](boost::shared_ptr<ConditionBase> condition) {
+  auto add_func = [this, &is_success_condition](std::shared_ptr<ConditionBase> condition) {
     if (condition)
     {
       addMarker(condition->getName(), condition->getResult(), is_success_condition);
@@ -24,21 +25,21 @@ void ConditionVisualizer::publishMarker(ConditionManager& manager)
   manager.applyVisitorForFailureConditions(add_func);
   is_success_condition = true;
   manager.applyVisitorForSuccessConditions(add_func);
-  pub_marker_.publish(marker_array_);
+  pub_marker_->publish(marker_array_);
 }
 
 void ConditionVisualizer::addMarker(std::string name, bool result, bool is_success_condition)
 {
-  visualization_msgs::Marker marker;
+  visualization_msgs::msg::Marker marker;
   marker.header.frame_id = "base_link";
-  marker.header.stamp = ros::Time::now();
+  marker.header.stamp = node_->now();
 
   marker.ns = "conditions";
   marker.id = marker_array_.markers.size();
 
-  marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-  marker.action = visualization_msgs::Marker::ADD;
-  marker.lifetime = ros::Duration();
+  marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.lifetime = rclcpp::Duration(0);
 
   marker.scale.z = 2.0;
 


### PR DESCRIPTION
## Summary

**This package is a WIP as it is waiting on a number of packages.**
Straightforward port of the `scenario_conditions` package. This package is quite small and the ROS related changes are  

Notable Changes:
* Trying to remove boost dependencies where possible 
* Deprecation of some `pluginlib` methods (warning caught by compiler flags)
  * createInstance (returns raw pointer) -> createSharedInstance (returns std::shared_ptr)
* Pass in `rclcpp::Node::SharedPtr` through `ConditionManager` to `ConditionVisualizer` where it is used