### PR TITLE
Port scenario_intersection to ROS2

### DIFF
--- a/entity/scenario_intersection/CMakeLists.txt
+++ b/entity/scenario_intersection/CMakeLists.txt
@@ -1,58 +1,73 @@
-cmake_minimum_required(VERSION 2.8.3)
-
+cmake_minimum_required(VERSION 3.5)
 project(scenario_intersection)
 
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  scenario_api
-  scenario_logger
-  scenario_logger_msgs
-  scenario_utility
-  )
+### Dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-find_package(yaml-cpp REQUIRED)
+# find_package(catkin REQUIRED COMPONENTS
+#   roscpp
+#   scenario_api
+#   scenario_logger
+#   scenario_logger_msgs
+#   scenario_utility
+#   )
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp
-                 scenario_api
-                 scenario_logger
-                 scenario_logger_msgs
-  )
+# find_package(yaml-cpp REQUIRED)
 
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${YAML_CPP_INCLUDE_DIR}
-  )
+# catkin_package(
+#   INCLUDE_DIRS include
+#   LIBRARIES ${PROJECT_NAME}
+#   CATKIN_DEPENDS roscpp
+#                  scenario_api
+#                  scenario_logger
+#                  scenario_logger_msgs
+#   )
 
-add_library(${PROJECT_NAME} SHARED
+### Target executable
+set(SCENARIO_INTERSECTION_SRC
   src/arrow.cpp
-  src/color.cpp
-  src/intersection.cpp
-  src/intersection_manager.cpp
-  )
+  # src/color.cpp
+  # src/intersection.cpp
+  # src/intersection_manager.cpp
+)
 
-add_dependencies(${PROJECT_NAME}
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-  )
+# include_directories(
+#   include
+#   ${catkin_INCLUDE_DIRS}
+#   ${YAML_CPP_INCLUDE_DIR}
+#   )
 
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-  ${YAML_CPP_LIBRARIES}
-  )
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  ${SCENARIO_INTERSECTION_SRC}
+)
 
-install(
-  DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+# add_dependencies(${PROJECT_NAME}
+#   ${${PROJECT_NAME}_EXPORTED_TARGETS}
+#   ${catkin_EXPORTED_TARGETS}
+#   )
 
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+# target_link_libraries(${PROJECT_NAME}
+#   ${catkin_LIBRARIES}
+#   ${YAML_CPP_LIBRARIES}
+#   )
 
+# install(
+#   DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
+# install(
+#   TARGETS ${PROJECT_NAME}
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+ament_auto_package()

--- a/entity/scenario_intersection/CMakeLists.txt
+++ b/entity/scenario_intersection/CMakeLists.txt
@@ -13,61 +13,16 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-# find_package(catkin REQUIRED COMPONENTS
-#   roscpp
-#   scenario_api
-#   scenario_logger
-#   scenario_logger_msgs
-#   scenario_utility
-#   )
-
-# find_package(yaml-cpp REQUIRED)
-
-# catkin_package(
-#   INCLUDE_DIRS include
-#   LIBRARIES ${PROJECT_NAME}
-#   CATKIN_DEPENDS roscpp
-#                  scenario_api
-#                  scenario_logger
-#                  scenario_logger_msgs
-#   )
-
 ### Target executable
 set(SCENARIO_INTERSECTION_SRC
   src/arrow.cpp
-  # src/color.cpp
-  # src/intersection.cpp
-  # src/intersection_manager.cpp
+  src/color.cpp
+  src/intersection.cpp
+  src/intersection_manager.cpp
 )
-
-# include_directories(
-#   include
-#   ${catkin_INCLUDE_DIRS}
-#   ${YAML_CPP_INCLUDE_DIR}
-#   )
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   ${SCENARIO_INTERSECTION_SRC}
 )
-
-# add_dependencies(${PROJECT_NAME}
-#   ${${PROJECT_NAME}_EXPORTED_TARGETS}
-#   ${catkin_EXPORTED_TARGETS}
-#   )
-
-# target_link_libraries(${PROJECT_NAME}
-#   ${catkin_LIBRARIES}
-#   ${YAML_CPP_LIBRARIES}
-#   )
-
-# install(
-#   DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
-
-# install(
-#   TARGETS ${PROJECT_NAME}
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 ament_auto_package()

--- a/entity/scenario_intersection/include/scenario_intersection/arrow.h
+++ b/entity/scenario_intersection/include/scenario_intersection/arrow.h
@@ -3,7 +3,6 @@
 
 #include <ostream>
 #include <string>
-#include <unordered_map>
 #include <utility>
 
 #include <scenario_intersection/utility.h>

--- a/entity/scenario_intersection/include/scenario_intersection/color.h
+++ b/entity/scenario_intersection/include/scenario_intersection/color.h
@@ -3,7 +3,6 @@
 
 #include <ostream>
 #include <string>
-#include <unordered_map>
 #include <utility>
 
 #include <scenario_intersection/utility.h>

--- a/entity/scenario_intersection/include/scenario_intersection/intersection.h
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection.h
@@ -96,6 +96,7 @@ class Intersection
                     target_, boost::lexical_cast<std::string>(each), false);
               });
         }
+        return false;
       }
 
       bool operator()(ScenarioAPI& simulator) const

--- a/entity/scenario_intersection/include/scenario_intersection/intersection.h
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection.h
@@ -12,7 +12,7 @@
 #include <rclcpp/logging.hpp>
 #include <rclcpp/logger.hpp>
 
-// #include <scenario_api/scenario_api_core.h>
+#include <scenario_api/scenario_api_core.h>
 #include <scenario_intersection/arrow.h>
 #include <scenario_intersection/color.h>
 #include <scenario_intersection/utility.h>
@@ -68,40 +68,40 @@ class Intersection
         }
       }
 
-      // bool changeColor(ScenarioAPI& simulator) const
-      // {
-      //   if (target_ < 0 or color_ == Color::Blank)
-      //   {
-      //     return simulator.resetTrafficLightColor(target_, false);
-      //   }
-      //   else // NOTE: Maybe specified illiegal traffic-light-id.
-      //   {
-      //     return simulator.setTrafficLightColor(target_, boost::lexical_cast<std::string>(color_), false);
-      //   }
-      // }
+      bool changeColor(ScenarioAPI& simulator) const
+      {
+        if (target_ < 0 or color_ == Color::Blank)
+        {
+          return simulator.resetTrafficLightColor(target_, false);
+        }
+        else // NOTE: Maybe specified illiegal traffic-light-id.
+        {
+          return simulator.setTrafficLightColor(target_, boost::lexical_cast<std::string>(color_), false);
+        }
+      }
 
-      // bool changeArrow(ScenarioAPI& simulator) const
-      // {
-      //   simulator.resetTrafficLightArrow(target_, false);
+      bool changeArrow(ScenarioAPI& simulator) const
+      {
+        simulator.resetTrafficLightArrow(target_, false);
 
-      //   if (0 <= target_)
-      //   {
-      //     return
-      //       std::all_of(
-      //         std::begin(arrows_), std::end(arrows_),
-      //         [&](const auto& each)
-      //         {
-      //           return
-      //             simulator.setTrafficLightArrow(
-      //               target_, boost::lexical_cast<std::string>(each), false);
-      //         });
-      //   }
-      // }
+        if (0 <= target_)
+        {
+          return
+            std::all_of(
+              std::begin(arrows_), std::end(arrows_),
+              [&](const auto& each)
+              {
+                return
+                  simulator.setTrafficLightArrow(
+                    target_, boost::lexical_cast<std::string>(each), false);
+              });
+        }
+      }
 
-      // bool operator()(ScenarioAPI& simulator) const
-      // {
-      //   return changeColor(simulator) and changeArrow(simulator);
-      // }
+      bool operator()(ScenarioAPI& simulator) const
+      {
+        return changeColor(simulator) and changeArrow(simulator);
+      }
     };
 
     std::vector<Transition> transitions_;
@@ -137,21 +137,21 @@ class Intersection
       }
     }
 
-    // bool operator()(ScenarioAPI& simulator) const
-    // {
-    //   return
-    //     std::all_of(
-    //       transitions_.begin(), transitions_.end(),
-    //       [&](const auto& transition)
-    //       {
-    //         return transition(simulator);
-    //       });
-    // }
+    bool operator()(ScenarioAPI& simulator) const
+    {
+      return
+        std::all_of(
+          transitions_.begin(), transitions_.end(),
+          [&](const auto& transition)
+          {
+            return transition(simulator);
+          });
+    }
   };
 
   const YAML::Node script_;
 
-  // const std::shared_ptr<ScenarioAPI> simulator_;
+  const std::shared_ptr<ScenarioAPI> simulator_;
 
   std::vector<std::size_t> ids_;
 
@@ -160,8 +160,7 @@ class Intersection
   std::string current_state_;
 
 public:
-  Intersection(const YAML::Node&, rclcpp::Logger&);
-  // Intersection(const YAML::Node&, rclcpp::Logger&, const std::shared_ptr<ScenarioAPI>&);
+  Intersection(const YAML::Node&, const std::shared_ptr<ScenarioAPI>&);
 
   bool change_to(const std::string& the_state);
 

--- a/entity/scenario_intersection/include/scenario_intersection/intersection.h
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection.h
@@ -113,7 +113,7 @@ class Intersection
       transitions_.emplace_back();
     }
 
-    Controller(const YAML::Node & node, rclcpp::Logger & logger)
+    Controller(const YAML::Node & node, const rclcpp::Logger & logger)
     {
       if (const auto traffic_lights {node["TrafficLight"]})
       {

--- a/entity/scenario_intersection/include/scenario_intersection/intersection.h
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection.h
@@ -112,7 +112,7 @@ class Intersection
       transitions_.emplace_back();
     }
 
-    Controller(const YAML::Node& node, rclcpp::Logger & logger)
+    Controller(const YAML::Node & node, rclcpp::Logger & logger)
     {
       if (const auto traffic_lights {node["TrafficLight"]})
       {
@@ -121,7 +121,8 @@ class Intersection
           if (const auto arrow { each["Arrow"] })
           {
             // NOTE: tag 'Arrow' is deperecated
-            RCLCPP_WARN_STREAM(logger, "Tag 'Arrow: <String>' is deperecated. Use 'Arrows: [<String>*]'");
+            RCLCPP_WARN_STREAM(
+              logger, "Tag 'Arrow: <String>' is deprecated. Use 'Arrows: [<String>*]'");
             transitions_.emplace_back(each["Id"], each["Color"], arrow);
           }
           else

--- a/entity/scenario_intersection/include/scenario_intersection/intersection_manager.h
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection_manager.h
@@ -5,8 +5,10 @@
 #include <unordered_map>
 
 #include <yaml-cpp/yaml.h>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/logger.hpp>
 
-#include <scenario_api/scenario_api_core.h>
+// #include <scenario_api/scenario_api_core.h>
 #include <scenario_intersection/intersection.h>
 #include <scenario_utility/scenario_utility.h>
 
@@ -17,20 +19,24 @@ class IntersectionManager
 {
   const YAML::Node node_;
 
-  const std::shared_ptr<ScenarioAPI> simulator_;
+  rclcpp::Logger logger_;
+
+  // const std::shared_ptr<ScenarioAPI> simulator_;
 
   std::unordered_map<std::string, scenario_intersection::Intersection> intersections_;
 
 public:
   IntersectionManager(
     const YAML::Node&,
-    const std::shared_ptr<ScenarioAPI>&);
+    // const std::shared_ptr<ScenarioAPI>&,
+    rclcpp::Logger&
+  );
 
   bool initialize(const YAML::Node&);
 
   bool change(const std::string&, const std::string&);
 
-  simulation_is update(const ros::Time&);
+  simulation_is update();
 
   template <typename... Ts>
   constexpr decltype(auto) at(Ts&&... xs) const

--- a/entity/scenario_intersection/include/scenario_intersection/intersection_manager.h
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection_manager.h
@@ -8,7 +8,7 @@
 #include <rclcpp/logging.hpp>
 #include <rclcpp/logger.hpp>
 
-// #include <scenario_api/scenario_api_core.h>
+#include <scenario_api/scenario_api_core.h>
 #include <scenario_intersection/intersection.h>
 #include <scenario_utility/scenario_utility.h>
 
@@ -21,15 +21,14 @@ class IntersectionManager
 
   rclcpp::Logger logger_;
 
-  // const std::shared_ptr<ScenarioAPI> simulator_;
+  const std::shared_ptr<ScenarioAPI> simulator_;
 
   std::unordered_map<std::string, scenario_intersection::Intersection> intersections_;
 
 public:
   IntersectionManager(
     const YAML::Node&,
-    // const std::shared_ptr<ScenarioAPI>&,
-    rclcpp::Logger&
+    const std::shared_ptr<ScenarioAPI>&
   );
 
   bool initialize(const YAML::Node&);

--- a/entity/scenario_intersection/include/scenario_intersection/utility.h
+++ b/entity/scenario_intersection/include/scenario_intersection/utility.h
@@ -3,7 +3,8 @@
 
 #include <string>
 
-#include <ros/ros.h>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/logger.hpp>
 
 #include <yaml-cpp/yaml.h>
 
@@ -14,7 +15,7 @@ template <typename T>
 T convert(const std::string&);
 
 template <typename T, typename F>
-decltype(auto) if_exist(const YAML::Node& node, const std::string& key, F&& consequent)
+decltype(auto) if_exist(const YAML::Node& node, const std::string& key, F&& consequent, rclcpp::Logger & logger)
 {
   if (const auto& element {node[key]})
   {
@@ -24,14 +25,14 @@ decltype(auto) if_exist(const YAML::Node& node, const std::string& key, F&& cons
     }
     catch (const YAML::BadConversion&)
     {
-      ROS_ERROR_STREAM(
+      RCLCPP_ERROR_STREAM(logger,
         "A bad-conversion exception occurred when parsing the key '" << key << "'. "
         "You have specified in your scenario a value of a type that is not appropriate for that key.");
     }
   }
   else
   {
-    ROS_ERROR_STREAM("Missing key '" << key << "' in following tree.\n" << node);
+    RCLCPP_ERROR_STREAM(logger, "Missing key '" << key << "' in following tree.\n" << node);
   }
 }
 

--- a/entity/scenario_intersection/include/scenario_intersection/utility.h
+++ b/entity/scenario_intersection/include/scenario_intersection/utility.h
@@ -15,7 +15,7 @@ template <typename T>
 T convert(const std::string&);
 
 template <typename T, typename F>
-decltype(auto) if_exist(const YAML::Node& node, const std::string& key, F&& consequent, rclcpp::Logger & logger)
+decltype(auto) if_exist(const YAML::Node& node, const std::string& key, F&& consequent, const rclcpp::Logger & logger)
 {
   if (const auto& element {node[key]})
   {

--- a/entity/scenario_intersection/package.xml
+++ b/entity/scenario_intersection/package.xml
@@ -13,12 +13,12 @@
 
   <depend>rclcpp</depend>
   <depend>libgoogle-glog-dev</depend>
-  <!-- <depend>rosbag</depend> -->
   <!-- <depend>scenario_api</depend> -->
   <depend>scenario_utility</depend>
   <depend>scenario_logger</depend>
   <depend>scenario_logger_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
+  <depend>boost</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/entity/scenario_intersection/package.xml
+++ b/entity/scenario_intersection/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>libgoogle-glog-dev</depend>
   <!-- <depend>scenario_api</depend> -->
   <depend>scenario_utility</depend>
   <depend>scenario_logger</depend>

--- a/entity/scenario_intersection/package.xml
+++ b/entity/scenario_intersection/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <!-- <depend>scenario_api</depend> -->
+  <depend>scenario_api</depend>
   <depend>scenario_utility</depend>
   <depend>scenario_logger</depend>
   <depend>scenario_logger_msgs</depend>

--- a/entity/scenario_intersection/package.xml
+++ b/entity/scenario_intersection/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>scenario_intersection</name>
   <version>0.0.0</version>
   <description>The scenario_intersection package</description>
@@ -9,15 +9,19 @@
 
   <license>TODO</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>rclcpp</depend>
   <depend>libgoogle-glog-dev</depend>
-  <depend>rosbag</depend>
-  <depend>roscpp</depend>
-  <depend>scenario_api</depend>
+  <!-- <depend>rosbag</depend> -->
+  <!-- <depend>scenario_api</depend> -->
   <depend>scenario_utility</depend>
   <depend>scenario_logger</depend>
   <depend>scenario_logger_msgs</depend>
-  <depend>yaml-cpp</depend>
+  <depend>yaml_cpp_vendor</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>
 

--- a/entity/scenario_intersection/src/arrow.cpp
+++ b/entity/scenario_intersection/src/arrow.cpp
@@ -1,5 +1,7 @@
 #include <scenario_intersection/arrow.h>
 
+#include <unordered_map>
+
 namespace scenario_intersection
 {
 

--- a/entity/scenario_intersection/src/color.cpp
+++ b/entity/scenario_intersection/src/color.cpp
@@ -1,5 +1,7 @@
 #include <scenario_intersection/color.h>
 
+#include <unordered_map>
+
 namespace scenario_intersection
 {
 

--- a/entity/scenario_intersection/src/intersection.cpp
+++ b/entity/scenario_intersection/src/intersection.cpp
@@ -8,7 +8,7 @@ Intersection::Intersection(
   rclcpp::Logger & logger
   // const std::shared_ptr<ScenarioAPI>& simulator
 )
-  : script_(script)
+  : script_ {script}
   // , simulator_ {simulator}
 {
   if (const auto ids {script_["TrafficLightId"]})

--- a/entity/scenario_intersection/src/intersection.cpp
+++ b/entity/scenario_intersection/src/intersection.cpp
@@ -5,9 +5,11 @@ namespace scenario_intersection
 
 Intersection::Intersection(
   const YAML::Node& script,
-  const std::shared_ptr<ScenarioAPI>& simulator)
-  : script_ {script}
-  , simulator_ {simulator}
+  rclcpp::Logger & logger
+  // const std::shared_ptr<ScenarioAPI>& simulator
+)
+  : script_(script)
+  // , simulator_ {simulator}
 {
   if (const auto ids {script_["TrafficLightId"]})
   {
@@ -18,7 +20,7 @@ Intersection::Intersection(
   }
   else
   {
-    ROS_ERROR_STREAM("Each element of node 'Intersection' requires hash 'TrafficLightId'.");
+    RCLCPP_ERROR_STREAM(logger, "Each element of node 'Intersection' requires hash 'TrafficLightId'.");
   }
 
   if (const auto controls {script_["Control"]})
@@ -27,24 +29,26 @@ Intersection::Intersection(
     {
       if (const auto& state_name {each["StateName"]})
       {
-        change_to_.emplace(state_name.as<std::string>(), each);
+        change_to_.emplace(state_name.as<std::string>(), Controller(each, logger));
       }
       else
       {
-        ROS_ERROR_STREAM("Each element of node 'Control' requires hash 'StateName'.");
+        RCLCPP_ERROR_STREAM(logger, "Each element of node 'Control' requires hash 'StateName'.");
       }
     }
   }
   else
   {
-    ROS_ERROR_STREAM("Each element of node 'Intersection' requires hash 'Control'.");
+    RCLCPP_ERROR_STREAM(logger, "Each element of node 'Intersection' requires hash 'Control'.");
   }
 }
 
 bool Intersection::change_to(const std::string& the_state)
 {
   // NOTE: Any unspecified state names are treated as "Blank" state
-  return change_to_[current_state_ = the_state](*simulator_);
+  // TODO: simulator
+  // return change_to_[current_state_ = the_state](*simulator_);
+  return false;
 }
 
 const std::vector<std::size_t>& Intersection::ids() const
@@ -52,7 +56,7 @@ const std::vector<std::size_t>& Intersection::ids() const
   return ids_;
 }
 
-simulation_is Intersection::update(const ros::Time&)
+simulation_is Intersection::update()
 {
   return simulation_is::ongoing;
 }

--- a/entity/scenario_intersection/src/intersection.cpp
+++ b/entity/scenario_intersection/src/intersection.cpp
@@ -20,7 +20,8 @@ Intersection::Intersection(
   }
   else
   {
-    RCLCPP_ERROR_STREAM(logger, "Each element of node 'Intersection' requires hash 'TrafficLightId'.");
+    RCLCPP_ERROR_STREAM(
+      logger, "Each element of node 'Intersection' requires hash 'TrafficLightId'.");
   }
 
   if (const auto controls {script_["Control"]})
@@ -46,7 +47,6 @@ Intersection::Intersection(
 bool Intersection::change_to(const std::string& the_state)
 {
   // NOTE: Any unspecified state names are treated as "Blank" state
-  // TODO: simulator
   // return change_to_[current_state_ = the_state](*simulator_);
   return false;
 }

--- a/entity/scenario_intersection/src/intersection.cpp
+++ b/entity/scenario_intersection/src/intersection.cpp
@@ -5,12 +5,12 @@ namespace scenario_intersection
 
 Intersection::Intersection(
   const YAML::Node& script,
-  rclcpp::Logger & logger
-  // const std::shared_ptr<ScenarioAPI>& simulator
+  const std::shared_ptr<ScenarioAPI>& simulator
 )
   : script_ {script}
-  // , simulator_ {simulator}
+  , simulator_ {simulator}
 {
+  rclcpp::Logger logger = rclcpp::get_logger("scenario_intersection");
   if (const auto ids {script_["TrafficLightId"]})
   {
     for (const auto& each : ids)
@@ -47,8 +47,7 @@ Intersection::Intersection(
 bool Intersection::change_to(const std::string& the_state)
 {
   // NOTE: Any unspecified state names are treated as "Blank" state
-  // return change_to_[current_state_ = the_state](*simulator_);
-  return false;
+  return change_to_[current_state_ = the_state](*simulator_);
 }
 
 const std::vector<std::size_t>& Intersection::ids() const

--- a/entity/scenario_intersection/src/intersection_manager.cpp
+++ b/entity/scenario_intersection/src/intersection_manager.cpp
@@ -5,20 +5,19 @@ namespace scenario_intersection
 
 IntersectionManager::IntersectionManager(
   const YAML::Node& node,
-  // const std::shared_ptr<ScenarioAPI>& simulator)
-  rclcpp::Logger & logger)
+  const std::shared_ptr<ScenarioAPI>& simulator)
   : node_ {node}
-  // , simulator_ {simulator}
-  , logger_(logger)
+  , logger_(rclcpp::get_logger("scenario_intersection_manager"))
+  , simulator_ {simulator}
 {
   for (const auto& intersection : node_)
   {
     if (const auto name {intersection["Name"]})
     {
-      // intersections_.emplace(
-      //   std::piecewise_construct,
-      //   std::forward_as_tuple(name.as<std::string>()),
-      //   std::forward_as_tuple(intersection, simulator_));
+      intersections_.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(name.as<std::string>()),
+        std::forward_as_tuple(intersection, simulator_));
     }
     else
     {
@@ -69,7 +68,7 @@ try
 }
 catch (const std::out_of_range&)
 {
-  RCLCPP_ERROR_STREAM(logger_, "You trying to change state of unspecified intersection '" << target_intersection << "'.");
+  RCLCPP_ERROR_STREAM(logger_, "You are trying to change state of unspecified intersection '" << target_intersection << "'.");
   return false;
 }
 

--- a/entity/scenario_intersection/src/intersection_manager.cpp
+++ b/entity/scenario_intersection/src/intersection_manager.cpp
@@ -5,22 +5,24 @@ namespace scenario_intersection
 
 IntersectionManager::IntersectionManager(
   const YAML::Node& node,
-  const std::shared_ptr<ScenarioAPI>& simulator)
+  // const std::shared_ptr<ScenarioAPI>& simulator)
+  rclcpp::Logger & logger)
   : node_ {node}
-  , simulator_ {simulator}
+  // , simulator_ {simulator}
+  , logger_(logger)
 {
   for (const auto& intersection : node_)
   {
     if (const auto name {intersection["Name"]})
     {
-      intersections_.emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(name.as<std::string>()),
-        std::forward_as_tuple(intersection, simulator_));
+      // intersections_.emplace(
+      //   std::piecewise_construct,
+      //   std::forward_as_tuple(name.as<std::string>()),
+      //   std::forward_as_tuple(intersection, simulator_));
     }
     else
     {
-      ROS_ERROR_STREAM("Missing key 'Name' at element of 'Intersection'.");
+      RCLCPP_ERROR_STREAM(logger_, "Missing key 'Name' at element of 'Intersection'.");
     }
   }
 }
@@ -47,7 +49,7 @@ bool IntersectionManager::initialize(const YAML::Node& intersections)
           }
           else
           {
-            ROS_ERROR_STREAM("Missing key 'Name' at element of 'Story.Init.Intersection'.");
+            RCLCPP_ERROR_STREAM(logger_, "Missing key 'Name' at element of 'Story.Init.Intersection'.");
             return false;
           }
         });
@@ -67,11 +69,11 @@ try
 }
 catch (const std::out_of_range&)
 {
-  ROS_ERROR_STREAM("You trying to change state of unspecified intersection '" << target_intersection << "'.");
+  RCLCPP_ERROR_STREAM(logger_, "You trying to change state of unspecified intersection '" << target_intersection << "'.");
   return false;
 }
 
-simulation_is IntersectionManager::update(const ros::Time& now)
+simulation_is IntersectionManager::update()
 {
   return simulation_is::ongoing;
 }


### PR DESCRIPTION
Copied from @jilaada's PR https://github.com/tier4/scenario_runner.iv.universe/pull/13 where most of the work has happened:
> Relatively straightforward port of the scenario_intersection package. Some changes are not complete yet due to unmet dependencies.
> 
> Notable Changes:
>     * ros::Time is passed in as a method but not used - this was removed
>     * rosbag package was listed as a dependency in the package.xml - this was not seen anywhere and therefore removed
>     * Rearranged headers so they were only where they were needed

I only uncommented the relevant code and fixed all compiler errors on a branch where I merged in the `scenario_api` PR. I also changed the logger back to be defined by the package itself instead of requiring an external logger. I think passing it in would complicate `scenario_runner` a bit, which constructs these classes.