### PR TITLE
[scenario_logger] Fix toJson() declarations

### DIFF
--- a/logger/scenario_logger/include/scenario_logger/logger.h
+++ b/logger/scenario_logger/include/scenario_logger/logger.h
@@ -114,8 +114,8 @@ const rclcpp::Time& begin();
 std::string toIso6801(const rclcpp::Time& stamp);
 
 boost::property_tree::ptree toJson(const scenario_logger_msgs::msg::MetaData& data);
-boost::property_tree::ptree toJson(const scenario_logger_msgs::msg::LoggedData& data);
-boost::optional<boost::property_tree::ptree> toJson(const scenario_logger_msgs::msg::Log& data,
+boost::optional<boost::property_tree::ptree> toJson(const scenario_logger_msgs::msg::Log& data);
+boost::property_tree::ptree toJson(const scenario_logger_msgs::msg::LoggedData& data,
                                                     const rclcpp::Logger & rclcpp_logger);
 
 class Logger
@@ -125,6 +125,7 @@ class Logger
   boost::optional<std::string> log_output_path_;
 
   rclcpp::Time time_;
+  rclcpp::Logger rclcpp_logger_;
 
 public:
   Logger();

--- a/logger/scenario_logger/src/logger.cpp
+++ b/logger/scenario_logger/src/logger.cpp
@@ -28,6 +28,7 @@ LoggerInitializer::~LoggerInitializer()
 Logger::Logger()
   : data_ {}
   , log_output_path_ { boost::none }
+  , rclcpp_logger_(rclcpp::get_logger("scenario_logger"))
 {}
 
 void Logger::setStartDatetime(const rclcpp::Time& time)
@@ -71,7 +72,7 @@ void Logger::write()
     data_.metadata.end_datetime = toIso6801(now);
     data_.metadata.duration = (now - begin()).seconds();
 
-    boost::property_tree::write_json(log_output_path_.get(), toJson(data_));
+    boost::property_tree::write_json(log_output_path_.get(), toJson(data_, rclcpp_logger_));
   }
   else
   {
@@ -171,7 +172,8 @@ boost::property_tree::ptree toJson(const scenario_logger_msgs::msg::MetaData& da
   return pt;
 }
 
-boost::property_tree::ptree toJson(const scenario_logger_msgs::msg::LoggedData& data, const rclcpp::Logger & rclcpp_logger)
+boost::property_tree::ptree toJson(const scenario_logger_msgs::msg::LoggedData& data, const
+rclcpp::Logger & rclcpp_logger)
 {
   using namespace boost::property_tree;
   ptree pt,log_tree;


### PR DESCRIPTION
Fix the declarations of free functions that were broken during porting in https://github.com/tier4/scenario_runner.iv.universe/pull/7

The issue only came up as a consumer actually used this package in https://github.com/tier4/scenario_runner.iv.universe/pull/28
```
Starting >>> scenario_runner
--- stderr: scenario_runner                                       
/usr/bin/ld: /home/frederik.beaujean/AutowareArchitectureProposal/install/scenario_logger/lib/libscenario_logger.so: undefined reference to `scenario_logger::toJson[abi:cxx11](scenario_logger_msgs::msg::LoggedData_<std::allocator<void> > const&)'
```

These kinds of linker errors would have come up immediately if there had been unit tests to create an executable 