### PR TITLE
Remove spinning from scenario api autoware's timer callback.

### DIFF
--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -117,7 +117,6 @@ ScenarioAPIAutoware::~ScenarioAPIAutoware() {}
 
 void ScenarioAPIAutoware::timerCallbackFast()
 {
-  rclcpp::spin_some(node_->get_node_base_interface());
   getCurrentPoseFromTF();
   pubTrafficLight();
 }

--- a/scenario_runner/include/scenario_runner/scenario_runner.h
+++ b/scenario_runner/include/scenario_runner/scenario_runner.h
@@ -23,6 +23,8 @@ public:
     return simulator_->getMoveDistance();
   }
 
+  void spin_simulator();
+
   simulation_is currently;
 
 private:

--- a/scenario_runner/src/scenario_runner.cpp
+++ b/scenario_runner/src/scenario_runner.cpp
@@ -25,6 +25,10 @@ ScenarioRunner::ScenarioRunner()
   }
 }
 
+void ScenarioRunner::spin_simulator(){
+  rclcpp::spin_some(simulator_);
+}
+
 void ScenarioRunner::run()
 try
 {

--- a/scenario_runner/src/scenario_runner_node.cpp
+++ b/scenario_runner/src/scenario_runner_node.cpp
@@ -74,6 +74,7 @@ int main(int argc, char * argv[])
   */
     for (runner_ptr->run(); rclcpp::ok(); rclcpp::spin_some(runner_ptr))
     {
+      runner_ptr->spin_simulator();
       static auto previously{runner_ptr->currently};
 
       if (previously != runner_ptr->currently)
@@ -86,6 +87,7 @@ int main(int argc, char * argv[])
             {
               const auto ret = boost::exit_success;
               dump(ret);
+              rclcpp::shutdown();
               return ret;
             }
 
@@ -95,6 +97,7 @@ int main(int argc, char * argv[])
             {
               const auto ret = boost::exit_test_failure;
               dump(ret);
+              rclcpp::shutdown();
               return ret;
             }
 
@@ -111,12 +114,14 @@ int main(int argc, char * argv[])
       scenario_logger::log.write();
       const auto ret = boost::exit_failure;
       dump(ret);
+      rclcpp::shutdown();
       return ret;
     }
     else
     {
       SCENARIO_INFO_STREAM(CATEGORY(), "Simulation unexpectedly failed.");
       scenario_logger::log.write();
+      rclcpp::shutdown();
       return boost::exit_exception_failure;
     }
   } catch (const std::exception& e) {
@@ -129,4 +134,6 @@ int main(int argc, char * argv[])
     scenario_logger::log.write();
     dump(boost::exit_exception_failure);
   }
+  rclcpp::shutdown();
+  return 0;
 }


### PR DESCRIPTION
See https://github.com/tier4/scenario_runner.iv.universe/issues/32