### PR TITLE
Add/adjust copyright licenses

### DIFF
--- a/action/action_plugins/include/action_plugins/acceleration_action.hpp
+++ b/action/action_plugins/include/action_plugins/acceleration_action.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ACTION_PLUGINS_ACCELERATION_ACTION_H
 #define INCLUDED_ACTION_PLUGINS_ACCELERATION_ACTION_H
 

--- a/action/action_plugins/include/action_plugins/change_signal_action.hpp
+++ b/action/action_plugins/include/action_plugins/change_signal_action.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ACION_PLUGINS_CHANGE_SIGNAL_ACTION_H
 #define INCLUDED_ACION_PLUGINS_CHANGE_SIGNAL_ACTION_H
 

--- a/action/action_plugins/include/action_plugins/enable_action.hpp
+++ b/action/action_plugins/include/action_plugins/enable_action.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ACTION_PLUGINS_ENABLE_ACTION_H
 #define INCLUDED_ACTION_PLUGINS_ENABLE_ACTION_H
 

--- a/action/action_plugins/include/action_plugins/fault_injection_action.hpp
+++ b/action/action_plugins/include/action_plugins/fault_injection_action.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ACTION_PLUGINS_FAULT_INJECTION_ACTION_H
 #define INCLUDED_ACTION_PLUGINS_FAULT_INJECTION_ACTION_H
 

--- a/action/action_plugins/include/action_plugins/follow_route_action.hpp
+++ b/action/action_plugins/include/action_plugins/follow_route_action.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef ACION_PLUGINS_FOLLOW_ROUTE_ACTION_H_INCLUDED
 #define ACION_PLUGINS_FOLLOW_ROUTE_ACTION_H_INCLUDED
 

--- a/action/action_plugins/include/action_plugins/lane_change_action.hpp
+++ b/action/action_plugins/include/action_plugins/lane_change_action.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef ACION_PLUGINS_LANE_CHANGE_ACTION_H_INCLUDED
 #define ACION_PLUGINS_LANE_CHANGE_ACTION_H_INCLUDED
 

--- a/action/action_plugins/include/action_plugins/speed_action.hpp
+++ b/action/action_plugins/include/action_plugins/speed_action.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ACTION_PLUGINS_SPEED_ACTION_H
 #define INCLUDED_ACTION_PLUGINS_SPEED_ACTION_H
 

--- a/action/action_plugins/src/acceleration_action.cpp
+++ b/action/action_plugins/src/acceleration_action.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <action_plugins/acceleration_action.hpp>
 
 namespace action_plugins

--- a/action/action_plugins/src/change_signal_action.cpp
+++ b/action/action_plugins/src/change_signal_action.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <action_plugins/change_signal_action.hpp>
 
 namespace action_plugins

--- a/action/action_plugins/src/enable_action.cpp
+++ b/action/action_plugins/src/enable_action.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <action_plugins/enable_action.hpp>
 
 namespace action_plugins

--- a/action/action_plugins/src/fault_injection_action.cpp
+++ b/action/action_plugins/src/fault_injection_action.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <action_plugins/fault_injection_action.hpp>
 
 namespace action_plugins

--- a/action/action_plugins/src/follow_route_action.cpp
+++ b/action/action_plugins/src/follow_route_action.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "action_plugins/follow_route_action.hpp"
 #include "scenario_utility/scenario_utility.hpp"
 

--- a/action/action_plugins/src/lane_change_action.cpp
+++ b/action/action_plugins/src/lane_change_action.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <action_plugins/lane_change_action.hpp>
 
 namespace action_plugins

--- a/action/action_plugins/src/speed_action.cpp
+++ b/action/action_plugins/src/speed_action.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <action_plugins/speed_action.hpp>
 
 namespace action_plugins

--- a/action/scenario_actions/include/scenario_actions/action_manager.hpp
+++ b/action/scenario_actions/include/scenario_actions/action_manager.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_ACTIONS_ACTION_MANAGER_H_INCLUDED
 #define SCENARIO_ACTIONS_ACTION_MANAGER_H_INCLUDED
 

--- a/action/scenario_actions/include/scenario_actions/entity_action_base.hpp
+++ b/action/scenario_actions/include/scenario_actions/entity_action_base.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_ACTIONS_ENTITY_ACTION_BASE_H_INCLUDED
 #define SCENARIO_ACTIONS_ENTITY_ACTION_BASE_H_INCLUDED
 

--- a/action/scenario_actions/src/action_manager.cpp
+++ b/action/scenario_actions/src/action_manager.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_actions/action_manager.hpp>
 
 #include <scenario_logger/logger.hpp>

--- a/action/scenario_sequence/include/scenario_sequence/event.hpp
+++ b/action/scenario_sequence/include/scenario_sequence/event.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_SEQUENCE_EVENT_H_INCLUDED
 #define SCENARIO_SEQUENCE_EVENT_H_INCLUDED
 

--- a/action/scenario_sequence/include/scenario_sequence/event_manager.hpp
+++ b/action/scenario_sequence/include/scenario_sequence/event_manager.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_SEQUENCE_EVENT_MANAGER_H_INCLUDED
 #define SCENARIO_SEQUENCE_EVENT_MANAGER_H_INCLUDED
 

--- a/action/scenario_sequence/include/scenario_sequence/sequence.hpp
+++ b/action/scenario_sequence/include/scenario_sequence/sequence.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_SEQUENCE_SEQUENCE_H_INCLUDED
 #define SCENARIO_SEQUENCE_SEQUENCE_H_INCLUDED
 

--- a/action/scenario_sequence/include/scenario_sequence/sequence_manager.hpp
+++ b/action/scenario_sequence/include/scenario_sequence/sequence_manager.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_SEQUENCE_SEQUENCE_MANAGER_H_INCLUDED
 #define SCENARIO_SEQUENCE_SEQUENCE_MANAGER_H_INCLUDED
 

--- a/action/scenario_sequence/src/event.cpp
+++ b/action/scenario_sequence/src/event.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_sequence/event.hpp>
 
 namespace scenario_sequence

--- a/action/scenario_sequence/src/event_manager.cpp
+++ b/action/scenario_sequence/src/event_manager.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_sequence/event_manager.hpp>
 
 namespace scenario_sequence

--- a/action/scenario_sequence/src/sequence.cpp
+++ b/action/scenario_sequence/src/sequence.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_sequence/sequence.hpp>
 
 namespace scenario_sequence

--- a/action/scenario_sequence/src/sequence_manager.cpp
+++ b/action/scenario_sequence/src/sequence_manager.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_sequence/sequence_manager.hpp>
 
 namespace scenario_sequence

--- a/api/scenario_api/include/scenario_api/scenario_api_coordinate_manager.hpp
+++ b/api/scenario_api/include/scenario_api/scenario_api_coordinate_manager.hpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <tf2/convert.h>

--- a/api/scenario_api/include/scenario_api/scenario_api_core.hpp
+++ b/api/scenario_api/include/scenario_api/scenario_api_core.hpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef SCENARIO_API_SCENARIO_API_CORE_H_INCLUDED
 #define SCENARIO_API_SCENARIO_API_CORE_H_INCLUDED
 

--- a/api/scenario_api/include/scenario_api/scenario_calc_dist_utils.hpp
+++ b/api/scenario_api/include/scenario_api/scenario_calc_dist_utils.hpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef SCENARIO_API_SCENARIO_API_CALC_DIST_UTILS_H_INCLUDED
 #define SCENARIO_API_SCENARIO_API_CALC_DIST_UTILS_H_INCLUDED

--- a/api/scenario_api/src/scenario_api_calc_dist_utils.cpp
+++ b/api/scenario_api/src/scenario_api_calc_dist_utils.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_api/scenario_calc_dist_utils.hpp>
 
 #include <pcl/point_types.h>

--- a/api/scenario_api/src/scenario_api_core.cpp
+++ b/api/scenario_api/src/scenario_api_core.cpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <scenario_api/scenario_api_core.hpp>
 #include <scenario_api/scenario_calc_dist_utils.hpp>

--- a/api/scenario_api/src/scenario_api_node.cpp
+++ b/api/scenario_api/src/scenario_api_node.cpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <scenario_api/scenario_api_core.hpp>
 #include <scenario_api_utils/scenario_api_utils.hpp>

--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.hpp
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.hpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef SCENARIO_API_SCENARIO_API_AUTOWARE_H_INCLUDED
 #define SCENARIO_API_SCENARIO_API_AUTOWARE_H_INCLUDED

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <scenario_api_autoware/scenario_api_autoware.hpp>
 

--- a/api/scenario_api_utils/include/scenario_api_utils/scenario_api_utils.hpp
+++ b/api/scenario_api_utils/include/scenario_api_utils/scenario_api_utils.hpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef SCENARIO_API_SCENARIO_API_UTILS_H_INCLUDED
 #define SCENARIO_API_SCENARIO_API_UTILS_H_INCLUDED

--- a/api/scenario_api_utils/src/scenario_api_utils.cpp
+++ b/api/scenario_api_utils/src/scenario_api_utils.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_api_utils/scenario_api_utils.hpp>
 
 double normalizeRadian(const double rad, const double min_rad, const double max_rad)

--- a/condition/condition_plugins/include/condition_plugins/acceleration_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/acceleration_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONDITION_PLUGINS_ACCELERATION_CONDITION_H_INCLUDED
 #define CONDITION_PLUGINS_ACCELERATION_CONDITION_H_INCLUDED
 

--- a/condition/condition_plugins/include/condition_plugins/always_false_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/always_false_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef TEST_CONDITIONS_ALWAYS_FALSE_CONDITION_H_INCLUDED
 #define TEST_CONDITIONS_ALWAYS_FALSE_CONDITION_H_INCLUDED
 

--- a/condition/condition_plugins/include/condition_plugins/always_true_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/always_true_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef TEST_CONDITIONS_ALWAYS_TRUE_CONDITION_H_INCLUDED
 #define TEST_CONDITIONS_ALWAYS_TRUE_CONDITION_H_INCLUDED
 

--- a/condition/condition_plugins/include/condition_plugins/collision_by_entity_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/collision_by_entity_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONDITION_PLUGINS_COLLISION_BY_ENTITY_CONDITION_H_INCLUDED
 #define CONDITION_PLUGINS_COLLISION_BY_ENTITY_CONDITION_H_INCLUDED
 

--- a/condition/condition_plugins/include/condition_plugins/reach_position_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/reach_position_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONDITION_PLUGINS_REACH_POSITION_CONDITION_H_INCLUDED
 #define CONDITION_PLUGINS_REACH_POSITION_CONDITION_H_INCLUDED
 

--- a/condition/condition_plugins/include/condition_plugins/relative_distance_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/relative_distance_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_CONDITION_PLUGINS_RELATIVE_DISTANCE_CONDITION_H
 #define INCLUDED_CONDITION_PLUGINS_RELATIVE_DISTANCE_CONDITION_H
 

--- a/condition/condition_plugins/include/condition_plugins/signal_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/signal_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_CONDITION_PLUGINS_SIGNAL_CONDITION_H
 #define INCLUDED_CONDITION_PLUGINS_SIGNAL_CONDITION_H
 

--- a/condition/condition_plugins/include/condition_plugins/simulation_time_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/simulation_time_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONDITION_PLUGINS_SIMULATION_TIME_H_INCLUDED
 #define CONDITION_PLUGINS_SIMULATION_TIME_H_INCLUDED
 

--- a/condition/condition_plugins/include/condition_plugins/speed_condition.hpp
+++ b/condition/condition_plugins/include/condition_plugins/speed_condition.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONDITION_PLUGINS_SPEED_CONDITION_H_INCLUDED
 #define CONDITION_PLUGINS_SPEED_CONDITION_H_INCLUDED
 

--- a/condition/condition_plugins/src/accelaration_condition.cpp
+++ b/condition/condition_plugins/src/accelaration_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/acceleration_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/always_false_condition.cpp
+++ b/condition/condition_plugins/src/always_false_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/always_false_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/always_true_condition.cpp
+++ b/condition/condition_plugins/src/always_true_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/always_true_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/collision_by_entity_condition.cpp
+++ b/condition/condition_plugins/src/collision_by_entity_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/collision_by_entity_condition.hpp>
 #include <scenario_logger/logger.hpp>
 

--- a/condition/condition_plugins/src/reach_position_condition.cpp
+++ b/condition/condition_plugins/src/reach_position_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/reach_position_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/relative_distance_condition.cpp
+++ b/condition/condition_plugins/src/relative_distance_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/relative_distance_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/signal_condition.cpp
+++ b/condition/condition_plugins/src/signal_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/signal_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/simulation_time_condition.cpp
+++ b/condition/condition_plugins/src/simulation_time_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/simulation_time_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/speed_condition.cpp
+++ b/condition/condition_plugins/src/speed_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <condition_plugins/speed_condition.hpp>
 
 namespace condition_plugins

--- a/condition/condition_plugins/src/targets.cpp
+++ b/condition/condition_plugins/src/targets.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <src/accelaration_condition.cpp>
 #include <src/always_false_condition.cpp>
 #include <src/always_true_condition.cpp>

--- a/condition/scenario_conditions/include/scenario_conditions/condition_base.hpp
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_base.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_CONDITIONS_CONDITION_BASE_H_INCLUDED
 #define SCENARIO_CONDITIONS_CONDITION_BASE_H_INCLUDED
 

--- a/condition/scenario_conditions/include/scenario_conditions/condition_manager.hpp
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_manager.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_CONDITION_CONDITION_MANAGER_H_INCLUDED
 #define SCENARIO_CONDITION_CONDITION_MANAGER_H_INCLUDED
 

--- a/condition/scenario_conditions/include/scenario_conditions/condition_visualizer.hpp
+++ b/condition/scenario_conditions/include/scenario_conditions/condition_visualizer.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_CONDITIONS_CONDITION_LOGGER_H_INCLUDED
 #define SCENARIO_CONDITIONS_CONDITION_LOGGER_H_INCLUDED
 

--- a/condition/scenario_conditions/src/condition_manager.cpp
+++ b/condition/scenario_conditions/src/condition_manager.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_conditions/condition_manager.hpp>
 
 namespace scenario_conditions

--- a/condition/scenario_conditions/src/condition_visualizer.cpp
+++ b/condition/scenario_conditions/src/condition_visualizer.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "scenario_conditions/condition_visualizer.hpp"
 #include "scenario_conditions/condition_manager.hpp"
 

--- a/entity/entity_plugins/include/entity_plugins/bicycle_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/bicycle_entity.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ENTITY_PLUGINS_BICYCLE_ENTITY_H
 #define INCLUDED_ENTITY_PLUGINS_BICYCLE_ENTITY_H
 

--- a/entity/entity_plugins/include/entity_plugins/ego_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/ego_entity.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef ENTITY_PLUGINS_EGO_CAR_ENTITIY_H_INCLUDED
 #define ENTITY_PLUGINS_EGO_CAR_ENTITIY_H_INCLUDED
 

--- a/entity/entity_plugins/include/entity_plugins/motorbike_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/motorbike_entity.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ENTITY_PLUGINS_MOTORBIKE_ENTITY_H
 #define INCLUDED_ENTITY_PLUGINS_MOTORBIKE_ENTITY_H
 

--- a/entity/entity_plugins/include/entity_plugins/pedestrian_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/pedestrian_entity.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_ENTITY_PLUGINS_PEDESTRIAN_ENTITY_H
 #define INCLUDED_ENTITY_PLUGINS_PEDESTRIAN_ENTITY_H
 

--- a/entity/entity_plugins/include/entity_plugins/vehicle_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/vehicle_entity.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef ENTITY_PLUGINS_VEHICLE_ENTITY_H_INCLUDED
 #define ENTITY_PLUGINS_VEHICLE_ENTITY_H_INCLUDED
 

--- a/entity/entity_plugins/src/bicycle_entity.cpp
+++ b/entity/entity_plugins/src/bicycle_entity.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <entity_plugins/bicycle_entity.hpp>
 
 namespace entity_plugins

--- a/entity/entity_plugins/src/ego_entity.cpp
+++ b/entity/entity_plugins/src/ego_entity.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <entity_plugins/ego_entity.hpp>
 
 namespace entity_plugins

--- a/entity/entity_plugins/src/motobike_entity.cpp
+++ b/entity/entity_plugins/src/motobike_entity.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <entity_plugins/motorbike_entity.hpp>
 
 namespace entity_plugins

--- a/entity/entity_plugins/src/pedestrian_entity.cpp
+++ b/entity/entity_plugins/src/pedestrian_entity.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <entity_plugins/pedestrian_entity.hpp>
 
 namespace entity_plugins

--- a/entity/entity_plugins/src/vehicle_entity.cpp
+++ b/entity/entity_plugins/src/vehicle_entity.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <entity_plugins/vehicle_entity.hpp>
 
 namespace entity_plugins

--- a/entity/scenario_entities/include/scenario_entities/entity_base.hpp
+++ b/entity/scenario_entities/include/scenario_entities/entity_base.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_ENTITIES_ENTITIY_BASE_H_INCLUDED
 #define SCENARIO_ENTITIES_ENTITIY_BASE_H_INCLUDED
 

--- a/entity/scenario_entities/include/scenario_entities/entity_manager.hpp
+++ b/entity/scenario_entities/include/scenario_entities/entity_manager.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_ENTITIES_ENTITY_MANAGER_H_INCLUDED
 #define SCENARIO_ENTITIES_ENTITY_MANAGER_H_INCLUDED
 

--- a/entity/scenario_entities/src/entitiy_manager.cpp
+++ b/entity/scenario_entities/src/entitiy_manager.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_entities/entity_manager.hpp>
 #include <scenario_utility/parse.hpp>
 

--- a/entity/scenario_entities/src/entity_base.cpp
+++ b/entity/scenario_entities/src/entity_base.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_entities/entity_base.hpp>
 
 #include <sstream>

--- a/entity/scenario_intersection/include/scenario_intersection/arrow.hpp
+++ b/entity/scenario_intersection/include/scenario_intersection/arrow.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_SCENARIO_INTERSECTION_ARROW_H
 #define INCLUDED_SCENARIO_INTERSECTION_ARROW_H
 

--- a/entity/scenario_intersection/include/scenario_intersection/color.hpp
+++ b/entity/scenario_intersection/include/scenario_intersection/color.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_SCENARIO_INTERSECTION_COLOR_H
 #define INCLUDED_SCENARIO_INTERSECTION_COLOR_H
 

--- a/entity/scenario_intersection/include/scenario_intersection/intersection.hpp
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_INTERSECTION_INTERSECTION_H_INCLUDED
 #define SCENARIO_INTERSECTION_INTERSECTION_H_INCLUDED
 

--- a/entity/scenario_intersection/include/scenario_intersection/intersection_manager.hpp
+++ b/entity/scenario_intersection/include/scenario_intersection/intersection_manager.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_INTERSECTION_INTERSECTON_MANAGER_H_INCLUDED
 #define SCENARIO_INTERSECTION_INTERSECTON_MANAGER_H_INCLUDED
 

--- a/entity/scenario_intersection/include/scenario_intersection/utility.hpp
+++ b/entity/scenario_intersection/include/scenario_intersection/utility.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_INTERSECTION_UTILITY_H_INCLUDED
 #define SCENARIO_INTERSECTION_UTILITY_H_INCLUDED
 

--- a/entity/scenario_intersection/src/arrow.cpp
+++ b/entity/scenario_intersection/src/arrow.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_intersection/arrow.hpp>
 
 #include <unordered_map>

--- a/entity/scenario_intersection/src/color.cpp
+++ b/entity/scenario_intersection/src/color.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_intersection/color.hpp>
 
 #include <unordered_map>

--- a/entity/scenario_intersection/src/intersection.cpp
+++ b/entity/scenario_intersection/src/intersection.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_intersection/intersection.hpp>
 
 namespace scenario_intersection

--- a/entity/scenario_intersection/src/intersection_manager.cpp
+++ b/entity/scenario_intersection/src/intersection_manager.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_intersection/intersection_manager.hpp>
 
 namespace scenario_intersection

--- a/logger/scenario_logger/include/scenario_logger/logger.hpp
+++ b/logger/scenario_logger/include/scenario_logger/logger.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_LOGGER_LOGGER_H_INCLUDED
 #define SCENARIO_LOGGER_LOGGER_H_INCLUDED
 

--- a/logger/scenario_logger/src/logger.cpp
+++ b/logger/scenario_logger/src/logger.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_logger/logger.hpp>
 
 namespace scenario_logger

--- a/scenario_api/include/scenario_api_event.hpp
+++ b/scenario_api/include/scenario_api_event.hpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 class ScenarioAPIEvent {
  public:

--- a/scenario_api/src/scenario_api_event.cpp
+++ b/scenario_api/src/scenario_api_event.cpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <scenario_api_event.hpp>
 

--- a/scenario_expression/include/scenario_expression/expression.hpp
+++ b/scenario_expression/include/scenario_expression/expression.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDED_SCENARIO_EXPRESSION_EXPRESSION_H
 #define INCLUDED_SCENARIO_EXPRESSION_EXPRESSION_H
 

--- a/scenario_expression/src/expression.cpp
+++ b/scenario_expression/src/expression.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_expression/expression.hpp>
 
 namespace scenario_expression

--- a/scenario_runner/include/scenario_runner/scenario_runner.hpp
+++ b/scenario_runner/include/scenario_runner/scenario_runner.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_RUNNER_SCENARIO_RUNNER_H_INCLUDED
 #define SCENARIO_RUNNER_SCENARIO_RUNNER_H_INCLUDED
 

--- a/scenario_runner/src/scenario_runner.cpp
+++ b/scenario_runner/src/scenario_runner.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_logger/logger.hpp>
 #include <scenario_runner/scenario_runner.hpp>
 

--- a/scenario_runner/src/scenario_runner_node.cpp
+++ b/scenario_runner/src/scenario_runner_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <glog/logging.h>
 #include <scenario_logger/logger.hpp>
 #include <scenario_runner/scenario_runner.hpp>

--- a/scenario_utility/include/scenario_utility/converter.hpp
+++ b/scenario_utility/include/scenario_utility/converter.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_UTILS_CONVERTER_H_INCLUDED
 #define SCENARIO_UTILS_CONVERTER_H_INCLUDED
 

--- a/scenario_utility/include/scenario_utility/misc.hpp
+++ b/scenario_utility/include/scenario_utility/misc.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_UTILS_MISC_H_INCLUDED
 #define SCENARIO_UTILS_MISC_H_INCLUDED
 

--- a/scenario_utility/include/scenario_utility/parse.hpp
+++ b/scenario_utility/include/scenario_utility/parse.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_UTILS_PARSE_H_INCLUDED
 #define SCENARIO_UTILS_PARSE_H_INCLUDED
 

--- a/scenario_utility/include/scenario_utility/scenario_utility.hpp
+++ b/scenario_utility/include/scenario_utility/scenario_utility.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SCENARIO_UTILS_SCENARIO_UTILS_H_INCLUDED
 #define SCENARIO_UTILS_SCENARIO_UTILS_H_INCLUDED
 

--- a/scenario_utility/src/converter.cpp
+++ b/scenario_utility/src/converter.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_utility/converter.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Matrix3x3.h>

--- a/scenario_utility/src/misc.cpp
+++ b/scenario_utility/src/misc.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <scenario_utility/misc.hpp>
 
 // namespace scenario_utility

--- a/scenario_utility/src/parse.cpp
+++ b/scenario_utility/src/parse.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "scenario_utility/parse.hpp"
 
 inline namespace scenario_utility


### PR DESCRIPTION
See https://github.com/tier4/Pilot.Auto/pull/143.
Second commit was generated by `comm -2 -3 <(fd . -e hpp -e cpp | sort) <(rg -i Copyright --files-with-matches -g '*.cpp' -g '*.hpp' | sort) | xargs -L 1 ament_copyright --add-missing 'Tier IV, Inc.' apache2`