### PR TITLE
Enable lints in scenario_utility

### DIFF
--- a/scenario_utility/CMakeLists.txt
+++ b/scenario_utility/CMakeLists.txt
@@ -4,6 +4,8 @@ project(scenario_utility)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -23,6 +25,11 @@ set(SCENARIO_UTILITY_SRC
 ament_auto_add_library(scenario_utility SHARED
   ${SCENARIO_UTILITY_SRC}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package()
 

--- a/scenario_utility/include/scenario_utility/converter.hpp
+++ b/scenario_utility/include/scenario_utility/converter.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SCENARIO_UTILS_CONVERTER_H_INCLUDED
-#define SCENARIO_UTILS_CONVERTER_H_INCLUDED
+#ifndef SCENARIO_UTILITY__CONVERTER_HPP_
+#define SCENARIO_UTILITY__CONVERTER_HPP_
 
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "geometry_msgs/msg/vector3.hpp"
@@ -24,11 +24,9 @@ namespace scenario_utility
 {
 inline namespace converter
 {
-
 geometry_msgs::msg::Quaternion convert(geometry_msgs::msg::Vector3 rpy);
 geometry_msgs::msg::Vector3 convert(geometry_msgs::msg::Quaternion quat);
-
 }  // namespace converter
 }  // namespace scenario_utility
 
-#endif  // SCENARIO_UTILS_CONVERTER_H_INCLUDED
+#endif  // SCENARIO_UTILITY__CONVERTER_HPP_

--- a/scenario_utility/include/scenario_utility/misc.hpp
+++ b/scenario_utility/include/scenario_utility/misc.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SCENARIO_UTILS_MISC_H_INCLUDED
-#define SCENARIO_UTILS_MISC_H_INCLUDED
+#ifndef SCENARIO_UTILITY__MISC_HPP_
+#define SCENARIO_UTILITY__MISC_HPP_
 
 #include <ostream>
 
@@ -30,58 +30,83 @@ enum class simulation_is : int
   succeeded,
 };
 
-std::ostream& operator<<(std::ostream&, const simulation_is&);
+std::ostream & operator<<(std::ostream &, const simulation_is &);
 
-constexpr simulation_is operator &&(const simulation_is& lhs,
-                                    const simulation_is& rhs)
+constexpr simulation_is operator&&(
+  const simulation_is & lhs,
+  const simulation_is & rhs)
 {
   using comparable = std::underlying_type<simulation_is>::type;
   return
     static_cast<simulation_is>(
-      std::min<comparable>(
-        static_cast<comparable>(lhs),
-        static_cast<comparable>(rhs)));
+    std::min<comparable>(
+      static_cast<comparable>(lhs),
+      static_cast<comparable>(rhs)));
 }
 
-constexpr simulation_is operator ||(const simulation_is& lhs,
-                                    const simulation_is& rhs)
+constexpr simulation_is operator||(
+  const simulation_is & lhs,
+  const simulation_is & rhs)
 {
   using comparable = std::underlying_type<simulation_is>::type;
   return
     static_cast<simulation_is>(
-      std::max<comparable>(
-        static_cast<comparable>(lhs),
-        static_cast<comparable>(rhs)));
+    std::max<comparable>(
+      static_cast<comparable>(lhs),
+      static_cast<comparable>(rhs)));
 }
 
 
-static_assert( ( simulation_is::succeeded && simulation_is::succeeded ) == simulation_is::succeeded, "");
-static_assert( ( simulation_is::succeeded && simulation_is::ongoing   ) == simulation_is::ongoing  , "");
-static_assert( ( simulation_is::succeeded && simulation_is::failed    ) == simulation_is::failed   , "");
+static_assert(
+  ( simulation_is::succeeded && simulation_is::succeeded ) == simulation_is::succeeded,
+  "");
+static_assert(
+  ( simulation_is::succeeded && simulation_is::ongoing   ) == simulation_is::ongoing,
+  "");
+static_assert(
+  ( simulation_is::succeeded && simulation_is::failed    ) == simulation_is::failed,
+  "");
 
-static_assert( ( simulation_is::ongoing   && simulation_is::succeeded ) == simulation_is::ongoing  , "");
-static_assert( ( simulation_is::ongoing   && simulation_is::ongoing   ) == simulation_is::ongoing  , "");
-static_assert( ( simulation_is::ongoing   && simulation_is::failed    ) == simulation_is::failed   , "");
+static_assert(
+  ( simulation_is::ongoing && simulation_is::succeeded ) == simulation_is::ongoing,
+  "");
+static_assert(
+  ( simulation_is::ongoing && simulation_is::ongoing   ) == simulation_is::ongoing,
+  "");
+static_assert( ( simulation_is::ongoing && simulation_is::failed    ) == simulation_is::failed, "");
 
-static_assert( ( simulation_is::failed    && simulation_is::succeeded ) == simulation_is::failed   , "");
-static_assert( ( simulation_is::failed    && simulation_is::ongoing   ) == simulation_is::failed   , "");
-static_assert( ( simulation_is::failed    && simulation_is::failed    ) == simulation_is::failed   , "");
+static_assert( ( simulation_is::failed && simulation_is::succeeded ) == simulation_is::failed, "");
+static_assert( ( simulation_is::failed && simulation_is::ongoing   ) == simulation_is::failed, "");
+static_assert( ( simulation_is::failed && simulation_is::failed    ) == simulation_is::failed, "");
 
 
-static_assert( ( simulation_is::succeeded || simulation_is::succeeded ) == simulation_is::succeeded, "");
-static_assert( ( simulation_is::succeeded || simulation_is::ongoing   ) == simulation_is::succeeded, "");
-static_assert( ( simulation_is::succeeded || simulation_is::failed    ) == simulation_is::succeeded, "");
+static_assert(
+  ( simulation_is::succeeded || simulation_is::succeeded ) == simulation_is::succeeded,
+  "");
+static_assert(
+  ( simulation_is::succeeded || simulation_is::ongoing   ) == simulation_is::succeeded,
+  "");
+static_assert(
+  ( simulation_is::succeeded || simulation_is::failed    ) == simulation_is::succeeded,
+  "");
 
-static_assert( ( simulation_is::ongoing   || simulation_is::succeeded ) == simulation_is::succeeded, "");
-static_assert( ( simulation_is::ongoing   || simulation_is::ongoing   ) == simulation_is::ongoing  , "");
-static_assert( ( simulation_is::ongoing   || simulation_is::failed    ) == simulation_is::ongoing  , "");
+static_assert(
+  ( simulation_is::ongoing || simulation_is::succeeded ) == simulation_is::succeeded,
+  "");
+static_assert(
+  ( simulation_is::ongoing || simulation_is::ongoing   ) == simulation_is::ongoing,
+  "");
+static_assert(
+  ( simulation_is::ongoing || simulation_is::failed    ) == simulation_is::ongoing,
+  "");
 
-static_assert( ( simulation_is::failed    || simulation_is::succeeded ) == simulation_is::succeeded, "");
-static_assert( ( simulation_is::failed    || simulation_is::ongoing   ) == simulation_is::ongoing  , "");
-static_assert( ( simulation_is::failed    || simulation_is::failed    ) == simulation_is::failed   , "");
+static_assert(
+  ( simulation_is::failed || simulation_is::succeeded ) == simulation_is::succeeded,
+  "");
+static_assert( ( simulation_is::failed || simulation_is::ongoing   ) == simulation_is::ongoing, "");
+static_assert( ( simulation_is::failed || simulation_is::failed    ) == simulation_is::failed, "");
 
 // }  inline namespace misc
 // }  namespace scenario_utility
 
-#endif  // SCENARIO_UTILS_MISC_H_INCLUDED
-
+#endif  // SCENARIO_UTILITY__MISC_HPP_

--- a/scenario_utility/include/scenario_utility/parse.hpp
+++ b/scenario_utility/include/scenario_utility/parse.hpp
@@ -12,19 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SCENARIO_UTILS_PARSE_H_INCLUDED
-#define SCENARIO_UTILS_PARSE_H_INCLUDED
+#ifndef SCENARIO_UTILITY__PARSE_HPP_
+#define SCENARIO_UTILITY__PARSE_HPP_
 
-#include "boost/optional.hpp"
-#include "geometry_msgs/msg/point_stamped.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "scenario_logger/logger.hpp"
-
+#include <functional>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+#include "scenario_logger/logger.hpp"
+
+#include "geometry_msgs/msg/point_stamped.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "yaml-cpp/yaml.h"
+#include "boost/optional.hpp"
 
 inline namespace scenario_utility
 {
@@ -32,147 +35,133 @@ inline namespace parse
 {
 std::vector<std::string> split(std::string s);
 
-template <typename T>
-T read_as(const YAML::Node&);
+template<typename T>
+T read_as(const YAML::Node &);
 
-#define READ_AS_SPECIALIZED_SIGNATURE(TYPENAME)                                \
-  template <>                                                                  \
-  TYPENAME read_as<TYPENAME>(const YAML::Node& node)
+#define READ_AS_SPECIALIZED_SIGNATURE(TYPENAME) \
+  template<> \
+  TYPENAME read_as<TYPENAME>(const YAML::Node & node)
 
 READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Point);
 READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Quaternion);
 READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Pose);
 READ_AS_SPECIALIZED_SIGNATURE(geometry_msgs::msg::PoseStamped);
 
-template <typename T>
-T read_essential(const YAML::Node& node, const std::string& key)
+template<typename T>
+T read_essential(const YAML::Node & node, const std::string & key)
 {
-  if (const auto x { node[key] })
-  {
-    try
-    {
+  if (const auto x {node[key]}) {
+    try {
       return x.as<T>();
-    }
-    catch (...)
-    {
-      SCENARIO_ERROR_THROW(CATEGORY(),
+    } catch (...) {
+      SCENARIO_ERROR_THROW(
+        CATEGORY(),
         "syntax-error: unexpected type appeared.\n\n" << node[key] << "\n");
     }
-  }
-  else
-  {
-    SCENARIO_ERROR_THROW(CATEGORY(),
+  } else {
+    SCENARIO_ERROR_THROW(
+      CATEGORY(),
       "syntax-error: missing essential clause " << key << ".\n\n" << node << "\n");
   }
 }
 
-#define READ_ESSENTIAL_SPECIALIZED_SIGNATURE(TYPENAME)                         \
-  template <>                                                                  \
-  TYPENAME read_essential<TYPENAME>(                                           \
-    const YAML::Node& node, const std::string& key)
+#define READ_ESSENTIAL_SPECIALIZED_SIGNATURE(TYPENAME) \
+  template<> \
+  TYPENAME read_essential<TYPENAME>( \
+    const YAML::Node & node, const std::string & key)
 
 READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Point);
 READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Quaternion);
 READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::Pose);
 READ_ESSENTIAL_SPECIALIZED_SIGNATURE(geometry_msgs::msg::PoseStamped);
 
-template <typename T>
+template<typename T>
 T read_optional(
-  const YAML::Node& node, const std::string& key, const T& value = {})
+  const YAML::Node & node, const std::string & key, const T & value = {})
 {
-  if (const auto x { node[key] })
-  {
-    try
-    {
+  if (const auto x {node[key]}) {
+    try {
       return x.as<T>();
-    }
-    catch (...)
-    {
-      SCENARIO_ERROR_THROW(CATEGORY(),
+    } catch (...) {
+      SCENARIO_ERROR_THROW(
+        CATEGORY(),
         "syntax-error: unmatched type.\n\n" << node[key] << "\n");
     }
-  }
-  else
-  {
-    SCENARIO_WARN_STREAM(CATEGORY(),
-      "syntax-warning: missing optional clause " << key << ". Use default value " << value << "\n\n" << node << "\n");
+  } else {
+    SCENARIO_WARN_STREAM(
+      CATEGORY(),
+      "syntax-warning: missing optional clause " << key <<
+        ". Use default value " << value << "\n\n" << node << "\n");
     return value;
   }
 }
 
-template <typename T, typename F,
-          typename =
-            typename std::enable_if<
-              std::is_function<
-                typename std::decay<F>::type
-              >::value
-            >::type>
-T read_optional(const YAML::Node& node, const std::string& key, F&& f)
+template<typename T, typename F,
+  typename =
+  typename std::enable_if<
+    std::is_function<
+      typename std::decay<F>::type
+    >::value
+  >::type>
+T read_optional(const YAML::Node & node, const std::string & key, F && f)
 {
-  if (const auto x { node[key] })
-  {
-    try
-    {
+  if (const auto x {node[key]}) {
+    try {
       return x.as<T>();
-    }
-    catch (...)
-    {
-      SCENARIO_ERROR_THROW(CATEGORY(),
+    } catch (...) {
+      SCENARIO_ERROR_THROW(
+        CATEGORY(),
         "syntax-error: unmatched type.\n\n" << node[key] << "\n");
     }
-  }
-  else
-  {
-    SCENARIO_WARN_STREAM(CATEGORY(),
-      "syntax-warning: missing optional clause " << key << ". Use default value.\n\n" << node << "\n");
+  } else {
+    SCENARIO_WARN_STREAM(
+      CATEGORY(),
+      "syntax-warning: missing optional clause " << key << ". Use default value.\n\n" << node <<
+        "\n");
     return f();
   }
 }
 
-template <typename F>
+template<typename F>
 decltype(auto) call_with_essential(
-  const YAML::Node& node, const std::string& key, F&& f)
+  const YAML::Node & node, const std::string & key, F && f)
 {
-  if (const auto x { node[key] })
-  {
+  if (const auto x {node[key]}) {
     return f(x);
-  }
-  else
-  {
-    SCENARIO_ERROR_THROW(CATEGORY(),
+  } else {
+    SCENARIO_ERROR_THROW(
+      CATEGORY(),
       "syntax-error: missing essential clause " << key << ".\n\n" << node << "\n");
   }
 }
 
-template <typename F>
+template<typename F>
 void call_with_optional(
-  const YAML::Node& node, const std::string& key, F&& f)
+  const YAML::Node & node, const std::string & key, F && f)
 {
-  if (const auto x { node[key] })
-  {
+  if (const auto x {node[key]}) {
     return f(x);
-  }
-  else
-  {
-    SCENARIO_WARN_STREAM(CATEGORY(),
+  } else {
+    SCENARIO_WARN_STREAM(
+      CATEGORY(),
       "syntax-warning: missing optional clause " << key << ".\n\n" << node << "\n");
   }
 }
 
-template <typename T>
+template<typename T>
 bool parseRule(std::string rule_string, std::function<bool(const T &, const T &)> & compare)
 {
-  if (rule_string == "Equal" or rule_string == "eq" or rule_string == "==") {
+  if (rule_string == "Equal" || rule_string == "eq" || rule_string == "==") {
     compare = std::equal_to<T>();
-  } else if (rule_string == "NotEqual" or rule_string == "neq" or rule_string == "!=") {
+  } else if (rule_string == "NotEqual" || rule_string == "neq" || rule_string == "!=") {
     compare = std::not_equal_to<T>();
-  } else if (rule_string == "GreaterThan" or rule_string == "gt" or rule_string == ">") {
+  } else if (rule_string == "GreaterThan" || rule_string == "gt" || rule_string == ">") {
     compare = std::greater<T>();
-  } else if (rule_string == "GreaterEqual" or rule_string == "ge" or rule_string == ">=") {
+  } else if (rule_string == "GreaterEqual" || rule_string == "ge" || rule_string == ">=") {
     compare = std::greater_equal<T>();
-  } else if (rule_string == "LessThan" or rule_string == "lt" or rule_string == "<") {
+  } else if (rule_string == "LessThan" || rule_string == "lt" || rule_string == "<") {
     compare = std::less<T>();
-  } else if (rule_string == "LessEqual" or rule_string == "le" or rule_string == "<=") {
+  } else if (rule_string == "LessEqual" || rule_string == "le" || rule_string == "<=") {
     compare = std::less_equal<T>();
   } else {
     return false;
@@ -182,4 +171,4 @@ bool parseRule(std::string rule_string, std::function<bool(const T &, const T &)
 }  // namespace parse
 }  // namespace scenario_utility
 
-#endif  // SCENARIO_UTILS_PARSE_H_INCLUDED
+#endif  // SCENARIO_UTILITY__PARSE_HPP_

--- a/scenario_utility/include/scenario_utility/scenario_utility.hpp
+++ b/scenario_utility/include/scenario_utility/scenario_utility.hpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SCENARIO_UTILS_SCENARIO_UTILS_H_INCLUDED
-#define SCENARIO_UTILS_SCENARIO_UTILS_H_INCLUDED
+#ifndef SCENARIO_UTILITY__SCENARIO_UTILITY_HPP_
+#define SCENARIO_UTILITY__SCENARIO_UTILITY_HPP_
 
 #include "parse.hpp"
 #include "converter.hpp"
 #include "misc.hpp"
 
-#endif // SCENARIO_UTILS_SCENARIO_UTILS_H_INCLUDED
-
+#endif  // SCENARIO_UTILITY__SCENARIO_UTILITY_HPP_

--- a/scenario_utility/package.xml
+++ b/scenario_utility/package.xml
@@ -17,6 +17,9 @@
   <depend>scenario_logger_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/scenario_utility/src/misc.cpp
+++ b/scenario_utility/src/misc.cpp
@@ -19,24 +19,22 @@
 // inline namespace misc
 // {
 
-std::ostream& operator<<(std::ostream& os, const simulation_is& is)
+std::ostream & operator<<(std::ostream & os, const simulation_is & is)
 {
-  switch (is)
-  {
-  case simulation_is::failed:
-    return os << "Failed";
+  switch (is) {
+    case simulation_is::failed:
+      return os << "Failed";
 
-  case simulation_is::ongoing:
-    return os << "Ongoing";
+    case simulation_is::ongoing:
+      return os << "Ongoing";
 
-  case simulation_is::succeeded:
-    return os << "Succeeded";
+    case simulation_is::succeeded:
+      return os << "Succeeded";
 
-  default:
-    return os << "Error";
+    default:
+      return os << "Error";
   }
 }
 
 // } // inline namespace misc
 // } // namespace scenario_utility
-

--- a/scenario_utility/src/parse.cpp
+++ b/scenario_utility/src/parse.cpp
@@ -14,20 +14,22 @@
 
 #include "scenario_utility/parse.hpp"
 
+#include <string>
+#include <vector>
+
 inline namespace scenario_utility
 {
 inline namespace parse
 {
-
-#define DEFINE_READ_ESSENTIAL_SPECIALIZATION(TYPENAME)                         \
-  READ_ESSENTIAL_SPECIALIZED_SIGNATURE(TYPENAME)                               \
-  {                                                                            \
-    return call_with_essential(node, key, read_as<TYPENAME>);                  \
-  }                                                                            \
+#define DEFINE_READ_ESSENTIAL_SPECIALIZATION(TYPENAME) \
+  READ_ESSENTIAL_SPECIALIZED_SIGNATURE(TYPENAME) \
+  { \
+    return call_with_essential(node, key, read_as<TYPENAME>); \
+  } \
   static_assert(true, "semicolon required after this macro")
 
-template <>
-geometry_msgs::msg::Point read_as<geometry_msgs::msg::Point>(const YAML::Node& node)
+template<>
+geometry_msgs::msg::Point read_as<geometry_msgs::msg::Point>(const YAML::Node & node)
 {
   geometry_msgs::msg::Point point {};
 
@@ -40,8 +42,8 @@ geometry_msgs::msg::Point read_as<geometry_msgs::msg::Point>(const YAML::Node& n
 
 DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::Point);
 
-template <>
-geometry_msgs::msg::Quaternion read_as<geometry_msgs::msg::Quaternion>(const YAML::Node& node)
+template<>
+geometry_msgs::msg::Quaternion read_as<geometry_msgs::msg::Quaternion>(const YAML::Node & node)
 {
   geometry_msgs::msg::Quaternion quaternion {};
 
@@ -55,8 +57,8 @@ geometry_msgs::msg::Quaternion read_as<geometry_msgs::msg::Quaternion>(const YAM
 
 DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::Quaternion);
 
-template <>
-geometry_msgs::msg::Pose read_as<geometry_msgs::msg::Pose>(const YAML::Node& node)
+template<>
+geometry_msgs::msg::Pose read_as<geometry_msgs::msg::Pose>(const YAML::Node & node)
 {
   geometry_msgs::msg::Pose pose {};
 
@@ -68,8 +70,8 @@ geometry_msgs::msg::Pose read_as<geometry_msgs::msg::Pose>(const YAML::Node& nod
 
 DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::Pose);
 
-template <>
-geometry_msgs::msg::PoseStamped read_as<geometry_msgs::msg::PoseStamped>(const YAML::Node& node)
+template<>
+geometry_msgs::msg::PoseStamped read_as<geometry_msgs::msg::PoseStamped>(const YAML::Node & node)
 {
   geometry_msgs::msg::PoseStamped pose_stamped {};
 
@@ -77,7 +79,8 @@ geometry_msgs::msg::PoseStamped read_as<geometry_msgs::msg::PoseStamped>(const Y
   // pose_stamped.header.stamp = ros::Time::now();
   // pose_stamped.pose = read_essential<geometry_msgs::msg::Pose>(node, "Pose");
   pose_stamped.pose.position = read_essential<geometry_msgs::msg::Point>(node, "Position");
-  pose_stamped.pose.orientation = read_essential<geometry_msgs::msg::Quaternion>(node, "Orientation");
+  pose_stamped.pose.orientation =
+    read_essential<geometry_msgs::msg::Quaternion>(node, "Orientation");
 
   return pose_stamped;
 }
@@ -87,14 +90,12 @@ DEFINE_READ_ESSENTIAL_SPECIALIZATION(geometry_msgs::msg::PoseStamped);
 std::vector<std::string> split(std::string s)
 {
   std::vector<std::string> v;
-  std::stringstream ss{ s };
+  std::stringstream ss{s};
   std::string buf;
-  while (std::getline(ss, buf, ','))
-  {
+  while (std::getline(ss, buf, ',')) {
     v.push_back(buf);
   }
   return v;
 }
-
 }  // namespace parse
 }  // namespace scenario_utility


### PR DESCRIPTION
The functions in `converter.hpp` seem unused, maybe they should be deleted?