### PR TITLE
Enable lints in entity_plugins

### DIFF
--- a/entity/entity_plugins/CMakeLists.txt
+++ b/entity/entity_plugins/CMakeLists.txt
@@ -4,6 +4,8 @@ project(entity_plugins)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -25,4 +27,9 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 pluginlib_export_plugin_description_file(scenario_entities plugins.xml)
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package()

--- a/entity/entity_plugins/include/entity_plugins/bicycle_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/bicycle_entity.hpp
@@ -29,4 +29,3 @@ struct BicycleEntity
 } // namespace entity_plugins
 
 #endif // INCLUDED_ENTITY_PLUGINS_BICYCLE_ENTITY_H
-

--- a/entity/entity_plugins/include/entity_plugins/ego_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/ego_entity.hpp
@@ -32,15 +32,15 @@ public:
   bool init() override;
 
   bool configure(
-    const YAML::Node&,
-    const std::shared_ptr<ScenarioAPI>&)
-    override;
+    const YAML::Node &,
+    const std::shared_ptr<ScenarioAPI> &)
+  override;
 
 private:
   std::string urdf_;
   std::string initial_frame_id_;
 
-  std::shared_ptr<scenario_actions::ActionManager>         action_manager_ptr_;
+  std::shared_ptr<scenario_actions::ActionManager> action_manager_ptr_;
   std::shared_ptr<scenario_actions::ActionManager> initial_action_manager_ptr_;
 };
 

--- a/entity/entity_plugins/include/entity_plugins/motorbike_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/motorbike_entity.hpp
@@ -29,4 +29,3 @@ struct MotorBikeEntity
 } // namespace entity_plugins
 
 #endif // INCLUDED_ENTITY_PLUGINS_MOTORBIKE_ENTITY_H
-

--- a/entity/entity_plugins/include/entity_plugins/pedestrian_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/pedestrian_entity.hpp
@@ -29,4 +29,3 @@ struct PedestrianEntity
 } // namespace entity_plugins
 
 #endif // INCLUDED_ENTITY_PLUGINS_PEDESTRIAN_ENTITY_H
-

--- a/entity/entity_plugins/include/entity_plugins/vehicle_entity.hpp
+++ b/entity/entity_plugins/include/entity_plugins/vehicle_entity.hpp
@@ -29,4 +29,3 @@ struct VehicleEntity
 }  // namespace entity_plugins
 
 #endif  // ENTITY_PLUGINS_VEHICLE_ENTITY_H_INCLUDED
-

--- a/entity/entity_plugins/package.xml
+++ b/entity/entity_plugins/package.xml
@@ -17,6 +17,9 @@
   <depend>scenario_logger</depend>
   <depend>scenario_utility</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <scenario_entities plugin="${prefix}/plugins.xml" />
     <build_type>ament_cmake</build_type>

--- a/entity/entity_plugins/src/bicycle_entity.cpp
+++ b/entity/entity_plugins/src/bicycle_entity.cpp
@@ -18,11 +18,10 @@ namespace entity_plugins
 {
 
 BicycleEntity::BicycleEntity()
-  : scenario_entities::EntityBase {"Bicycle"}
+: scenario_entities::EntityBase{"Bicycle"}
 {}
 
 } // namespace entity_plugins
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(entity_plugins::BicycleEntity, scenario_entities::EntityBase)
-

--- a/entity/entity_plugins/src/motobike_entity.cpp
+++ b/entity/entity_plugins/src/motobike_entity.cpp
@@ -18,11 +18,10 @@ namespace entity_plugins
 {
 
 MotorBikeEntity::MotorBikeEntity()
-  : scenario_entities::EntityBase {"MotorBike"}
+: scenario_entities::EntityBase{"MotorBike"}
 {}
 
 } // namespace entity_plugins
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(entity_plugins::MotorBikeEntity, scenario_entities::EntityBase)
-

--- a/entity/entity_plugins/src/pedestrian_entity.cpp
+++ b/entity/entity_plugins/src/pedestrian_entity.cpp
@@ -18,11 +18,10 @@ namespace entity_plugins
 {
 
 PedestrianEntity::PedestrianEntity()
-  : scenario_entities::EntityBase {"Pedestrian"}
+: scenario_entities::EntityBase{"Pedestrian"}
 {}
 
 } // namespace entity_plugins
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(entity_plugins::PedestrianEntity, scenario_entities::EntityBase)
-

--- a/entity/entity_plugins/src/vehicle_entity.cpp
+++ b/entity/entity_plugins/src/vehicle_entity.cpp
@@ -18,11 +18,10 @@ namespace entity_plugins
 {
 
 VehicleEntity::VehicleEntity()
-  : scenario_entities::EntityBase {"Vehicle"}
+: scenario_entities::EntityBase{"Vehicle"}
 {}
 
 }  // namespace scenario_entities
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(entity_plugins::VehicleEntity, scenario_entities::EntityBase)
-


### PR DESCRIPTION
The `EgoEntity::configure` function had no return value. The `configure()` function in the base class returns `true` if the `api` argument is not null. I chose to return false in case of a null argument, since `EgoEntity::configure` later dereferences `api_` (equal to `api` argument). But it's not super clear what this code is supposed to do – other failures are signaled as exceptions, and the calling code doesn't use the return value at all.