### PR TITLE
fix message type pf VelocityLimit

### DIFF
--- a/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.hpp
+++ b/api/scenario_api_autoware/include/scenario_api_autoware/scenario_api_autoware.hpp
@@ -28,7 +28,7 @@
 #include "autoware_vehicle_msgs/msg/engage.hpp"
 #include "autoware_system_msgs/msg/autoware_state.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
-#include "autoware_debug_msgs/msg/float32_stamped.hpp"
+#include "autoware_planning_msgs/msg/velocity_limit.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
@@ -186,7 +186,7 @@ private:
     pub_start_velocity_;  //!< @brief topic @publisher for initial velocity
   rclcpp::Publisher<autoware_vehicle_msgs::msg::Engage>::SharedPtr
     pub_autoware_engage_;  //!< @brief topic pubscriber for autoware engage
-  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr
+  rclcpp::Publisher<autoware_planning_msgs::msg::VelocityLimit>::SharedPtr
     pub_max_velocity_;  //!< @brief topic pubscriber for max velocity
   rclcpp::Publisher<autoware_planning_msgs::msg::LaneChangeCommand>::SharedPtr
     pub_lane_change_permission_;  //!< @brief topic pubscriber for approval of lane change

--- a/api/scenario_api_autoware/package.xml
+++ b/api/scenario_api_autoware/package.xml
@@ -10,7 +10,6 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_debug_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_control_msgs</depend>

--- a/api/scenario_api_autoware/src/scenario_api_autoware.cpp
+++ b/api/scenario_api_autoware/src/scenario_api_autoware.cpp
@@ -133,7 +133,7 @@ ScenarioAPIAutoware::ScenarioAPIAutoware(rclcpp::Node::SharedPtr node)
     durable_qos);
   LOG_SIMPLE(info() << "Advertise topic 'output/autoware_engage'");
   pub_max_velocity_ =
-    node_->create_publisher<autoware_debug_msgs::msg::Float32Stamped>(
+    node_->create_publisher<autoware_planning_msgs::msg::VelocityLimit>(
     "output/limit_velocity",
     durable_qos);
   LOG_SIMPLE(info() << "Advertise topic 'output/limit_velocity'");
@@ -455,10 +455,10 @@ bool ScenarioAPIAutoware::setMaxSpeed(double velocity)
 {
   LOG_SIMPLE(info() << "Sending max-speed " << velocity << " to Autoware");
 
-  autoware_debug_msgs::msg::Float32Stamped floatmsg;
-  floatmsg.stamp = node_->get_clock()->now();
-  floatmsg.data = velocity;
-  pub_max_velocity_->publish(floatmsg);
+  autoware_planning_msgs::msg::VelocityLimit vel_limit_msg;
+  vel_limit_msg.stamp = node_->get_clock()->now();
+  vel_limit_msg.max_velocity = velocity;
+  pub_max_velocity_->publish(vel_limit_msg);
   return true;  // TODO check success
 }
 


### PR DESCRIPTION
Fix message type of max velocity: autoware_debug_msgs/Float32Stamped -> autoware_planning_msgs/VelocityLimit